### PR TITLE
Add some guidelines to the issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/new-example.md
+++ b/.github/ISSUE_TEMPLATE/new-example.md
@@ -6,23 +6,31 @@ labels: ''
 assignees: ''
 
 ---
-
+<!--
 **⚠️ Please edit and complete this before submitting your game:**
+-->
 
 ## Describe the extension
+
+<!--
 A clear and concise description of what the extension is, how useful it is.
+-->
 
 ## Checklist
 
 - [ ] My game has a proper name in the game properties. 
+- [ ] My game package name behind with `com.example.`.
+- [ ] My game has all events unfolded.
 - [ ] I've added myself as the author in the game properties.
 - [ ] I've included a file called "README.md" with a description in proper English, explaining what this example is doing.
 - [ ] I confirm that this game and all of its resources can be integrated to this GitHub repository, distributed and MIT licensed.
 
 ## Game folder
 
+<!--
 Finally, attach a zip file containing your game and all its resources (images, sounds, etc...)
 
 You also may have to create an account on GitHub before posting.
 If your game is high quality and useful, it will be added to the list of GDevelop community examples.
 When you're ready, remove this last paragraph and click on "Submit new issue". Thanks 🙌
+-->


### PR DESCRIPTION
The com.example one of for displaying the warning about using a unique package name when exporting the game.

The events expanding one is because often users oversee the arrow to expand events and don't understand why they work without seeing the subevents.