### PR TITLE
Fix Anchor on left LoseZone for small screen

### DIFF
--- a/examples/ping-pong/ping-pong.json
+++ b/examples/ping-pong/ping-pong.json
@@ -11,6 +11,7 @@
     "folderProject": false,
     "orientation": "landscape",
     "packageName": "com.gdexample.pingpong",
+    "pixelsRounding": false,
     "projectUuid": "c853d0c1-9d2c-49ed-92d8-963b64507080",
     "scaleMode": "linear",
     "sizeOnStartupMode": "adaptWidth",
@@ -203,7 +204,7 @@
         "gridOffsetX": 0,
         "gridOffsetY": 0,
         "gridColor": 10401023,
-		"gridAlpha": 0.8,
+        "gridAlpha": 0.8,
         "snap": true,
         "zoomFactor": 0.32000000000000045,
         "windowMask": false
@@ -926,10 +927,10 @@
           "behaviors": [
             {
               "name": "Anchor",
+              "rightEdgeAnchor": 3,
               "type": "AnchorBehavior::AnchorBehavior",
               "bottomEdgeAnchor": 1,
               "leftEdgeAnchor": 3,
-              "rightEdgeAnchor": 0,
               "topEdgeAnchor": 2,
               "relativeToOriginalWindowSize": true
             }


### PR DESCRIPTION
Fix the anchor position of left LoseZone (white object) for small screen, see before:
![image](https://user-images.githubusercontent.com/1670670/131224310-14a2dd52-f771-4761-b148-6ad413641a37.png)
