### PR TITLE
Add New example label to issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/new-example.md
+++ b/.github/ISSUE_TEMPLATE/new-example.md
@@ -2,7 +2,7 @@
 name: New example
 about: Submit a new example to be added to the repository
 title: New example
-labels: 'New example'
+labels: '✨ New example'
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/new-example.md
+++ b/.github/ISSUE_TEMPLATE/new-example.md
@@ -2,7 +2,7 @@
 name: New example
 about: Submit a new example to be added to the repository
 title: New example
-labels: ''
+labels: 'New example'
 assignees: ''
 
 ---
@@ -19,7 +19,7 @@ A clear and concise description of what the example is, how useful it is.
 ## Checklist
 
 - [ ] My game has a proper name in the game properties. 
-- [ ] My game package name behind with `com.example.`.
+- [ ] My game package name behind with `com.gdexample.`.
 - [ ] My game has all events unfolded.
 - [ ] I've added myself as the author in the game properties.
 - [ ] I've included a file called "README.md" with a description in proper English, explaining what this example is doing.

--- a/.github/ISSUE_TEMPLATE/new-example.md
+++ b/.github/ISSUE_TEMPLATE/new-example.md
@@ -19,7 +19,7 @@ A clear and concise description of what the example is, how useful it is.
 ## Checklist
 
 - [ ] My game has a proper name in the game properties. 
-- [ ] My game package name behind with `com.gdexample.`.
+- [ ] My game package name behind with `com.example.`.
 - [ ] My game has all events unfolded.
 - [ ] I've added myself as the author in the game properties.
 - [ ] I've included a file called "README.md" with a description in proper English, explaining what this example is doing.


### PR DESCRIPTION
Changed package name standard to `com.gdexample.<project name>`.Done so that the examples don't accidentally conflict with the games made by users (Which have `com.example` as default) and also to be able to differentiate the examples.

Also added label `New example`