### PR TITLE
Add Starter tag to starters

### DIFF
--- a/__tests__/post-build/exampleShortHeaders.json.spec.js
+++ b/__tests__/post-build/exampleShortHeaders.json.spec.js
@@ -38,6 +38,7 @@ describe('filters.json post build checks', () => {
       ],
       tags: [
         'platformer',
+        'Starter',
         '',
         'Anchor',
         'Audio',

--- a/scripts/generate-database.js
+++ b/scripts/generate-database.js
@@ -162,6 +162,28 @@ const checkProjectResourceFiles = async (project, projectFolderPath) => {
 };
 
 /**
+ * Computes a list of static tags to add to the example based on its name.
+ * @param {string} exampleName
+ * @returns {string[]}
+ */
+const getStaticTags = (exampleName) => {
+  const staticTags = [];
+  const starterNames = [
+    'Platformer',
+    'Space shooter',
+    'Particle effects demo',
+    'Isometric game',
+    'Downhill bike physics demo',
+    'Game feel demo',
+    'Geometry monster',
+    'Pairs',
+  ];
+  if (starterNames.includes(exampleName)) staticTags.push('Starter');
+
+  return staticTags;
+};
+
+/**
  * Extract the information about the example games from the examples folder.
  * @param {libGDevelop} gd
  * @param {Record<string, gdPlatformExtension>} platformExtensionsMap
@@ -243,6 +265,9 @@ const extractExamples = async (
           /\r\n/g,
           '\n'
         );
+        const exampleName = formatExampleName(
+          path.basename(fileWithMetadata.name, '.json')
+        );
         const shortDescription = readmeFileContent.split('\n\n')[0];
         const description = readmeFileContent
           .split('\n\n')
@@ -251,6 +276,7 @@ const extractExamples = async (
 
         const tags = [
           ...fileWithMetadata.tags,
+          ...getStaticTags(exampleName),
           ...usedExtensions.map(({ fullName }) => fullName),
           ...eventsBasedExtensions.map(({ fullName }) => fullName),
         ];
@@ -276,9 +302,7 @@ const extractExamples = async (
         /** @type {Example} */
         const example = {
           id: getExampleUniqueId(fileWithMetadata.name, fileWithMetadata.tags),
-          name: formatExampleName(
-            path.basename(fileWithMetadata.name, '.json')
-          ),
+          name: exampleName,
           shortDescription,
           description,
           authorIds,


### PR DESCRIPTION
As part of the improvement of the homepage of the app, we will display the starters coming from the examples database, filtering on a tag "Starter".
This will have the advantage of using the starters from this repository, rather than the ones hardcoded in the app, which are way more up to date and of better quality!