### PR TITLE
[PingPong] Use new touch functions from GDevelop 5.0.132

### DIFF
--- a/examples/ping-pong/ping-pong.json
+++ b/examples/ping-pong/ping-pong.json
@@ -16,8 +16,9 @@
     "scaleMode": "linear",
     "sizeOnStartupMode": "adaptWidth",
     "useExternalSourceFiles": false,
-    "version": "1.0.0",
+    "version": "1.0.1",
     "name": "Ping Pong",
+    "description": "This example is a re-creation of the classic pong game in GDevelop, with some adaptations.",
     "author": "Leo Red (Midhil M)",
     "windowWidth": 1920,
     "windowHeight": 1080,
@@ -71,6 +72,11 @@
     },
     "authorIds": [
       "HBp2oDKV87gKFbdd1wyV1jRYRC13"
+    ],
+    "categories": [],
+    "playableDevices": [
+      "keyboard",
+      "mobile"
     ],
     "extensionProperties": [],
     "platforms": [
@@ -169,15 +175,6 @@
         "name": "assets\\barrier.png",
         "smoothed": true,
         "userAdded": false
-      },
-      {
-        "alwaysLoaded": false,
-        "file": "thumbnail.png",
-        "kind": "image",
-        "metadata": "",
-        "name": "thumbnail.png",
-        "smoothed": true,
-        "userAdded": true
       }
     ],
     "resourceFolders": []
@@ -1165,6 +1162,77 @@
                 }
               ],
               "events": []
+            },
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Comment",
+              "color": {
+                "b": 109,
+                "g": 230,
+                "r": 255,
+                "textB": 0,
+                "textG": 0,
+                "textR": 0
+              },
+              "comment": "Adapt the texts if we're on a touchscreen",
+              "comment2": ""
+            },
+            {
+              "disabled": false,
+              "folded": false,
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "SystemInfo::HasTouchScreen"
+                  },
+                  "parameters": [
+                    ""
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "actions": [
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "TextObject::String"
+                  },
+                  "parameters": [
+                    "PressSpaceText",
+                    "=",
+                    "\"Touch to continue\""
+                  ],
+                  "subInstructions": []
+                },
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "TextObject::String"
+                  },
+                  "parameters": [
+                    "Controls_Player2",
+                    "=",
+                    "\"Drag the paddle to move it\""
+                  ],
+                  "subInstructions": []
+                },
+                {
+                  "type": {
+                    "inverted": false,
+                    "value": "TextObject::String"
+                  },
+                  "parameters": [
+                    "Controls_Player1",
+                    "=",
+                    "\"Drag the paddle to move it\""
+                  ],
+                  "subInstructions": []
+                }
+              ],
+              "events": []
             }
           ]
         },
@@ -1256,188 +1324,168 @@
                 {
                   "disabled": false,
                   "folded": false,
+                  "type": "BuiltinCommonInstructions::Comment",
+                  "color": {
+                    "b": 109,
+                    "g": 230,
+                    "r": 255,
+                    "textB": 0,
+                    "textG": 0,
+                    "textR": 0
+                  },
+                  "comment": "Player 1 movement",
+                  "comment2": ""
+                },
+                {
+                  "disabled": false,
+                  "folded": false,
                   "type": "BuiltinCommonInstructions::Standard",
                   "conditions": [
                     {
                       "type": {
-                        "inverted": true,
-                        "value": "SystemInfo::HasTouchScreen"
+                        "inverted": false,
+                        "value": "KeyPressed"
                       },
                       "parameters": [
+                        "",
+                        "w"
+                      ],
+                      "subInstructions": []
+                    }
+                  ],
+                  "actions": [
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "AddForceAL"
+                      },
+                      "parameters": [
+                        "Paddle_1",
+                        "-90",
+                        "500",
                         ""
                       ],
                       "subInstructions": []
                     }
                   ],
-                  "actions": [],
-                  "events": [
+                  "events": []
+                },
+                {
+                  "disabled": false,
+                  "folded": false,
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [
                     {
-                      "disabled": false,
-                      "folded": false,
-                      "type": "BuiltinCommonInstructions::Comment",
-                      "color": {
-                        "b": 109,
-                        "g": 230,
-                        "r": 255,
-                        "textB": 0,
-                        "textG": 0,
-                        "textR": 0
+                      "type": {
+                        "inverted": false,
+                        "value": "KeyPressed"
                       },
-                      "comment": "Player 1 movement",
-                      "comment2": ""
-                    },
-                    {
-                      "disabled": false,
-                      "folded": false,
-                      "type": "BuiltinCommonInstructions::Standard",
-                      "conditions": [
-                        {
-                          "type": {
-                            "inverted": false,
-                            "value": "KeyPressed"
-                          },
-                          "parameters": [
-                            "",
-                            "w"
-                          ],
-                          "subInstructions": []
-                        }
+                      "parameters": [
+                        "",
+                        "s"
                       ],
-                      "actions": [
-                        {
-                          "type": {
-                            "inverted": false,
-                            "value": "AddForceAL"
-                          },
-                          "parameters": [
-                            "Paddle_1",
-                            "-90",
-                            "500",
-                            ""
-                          ],
-                          "subInstructions": []
-                        }
-                      ],
-                      "events": []
-                    },
-                    {
-                      "disabled": false,
-                      "folded": false,
-                      "type": "BuiltinCommonInstructions::Standard",
-                      "conditions": [
-                        {
-                          "type": {
-                            "inverted": false,
-                            "value": "KeyPressed"
-                          },
-                          "parameters": [
-                            "",
-                            "s"
-                          ],
-                          "subInstructions": []
-                        }
-                      ],
-                      "actions": [
-                        {
-                          "type": {
-                            "inverted": false,
-                            "value": "AddForceAL"
-                          },
-                          "parameters": [
-                            "Paddle_1",
-                            "90",
-                            "500",
-                            ""
-                          ],
-                          "subInstructions": []
-                        }
-                      ],
-                      "events": []
-                    },
-                    {
-                      "disabled": false,
-                      "folded": false,
-                      "type": "BuiltinCommonInstructions::Comment",
-                      "color": {
-                        "b": 109,
-                        "g": 230,
-                        "r": 255,
-                        "textB": 0,
-                        "textG": 0,
-                        "textR": 0
-                      },
-                      "comment": "Player 2 movement",
-                      "comment2": ""
-                    },
-                    {
-                      "disabled": false,
-                      "folded": false,
-                      "type": "BuiltinCommonInstructions::Standard",
-                      "conditions": [
-                        {
-                          "type": {
-                            "inverted": false,
-                            "value": "KeyPressed"
-                          },
-                          "parameters": [
-                            "",
-                            "Up"
-                          ],
-                          "subInstructions": []
-                        }
-                      ],
-                      "actions": [
-                        {
-                          "type": {
-                            "inverted": false,
-                            "value": "AddForceAL"
-                          },
-                          "parameters": [
-                            "Paddle_2",
-                            "-90",
-                            "500",
-                            ""
-                          ],
-                          "subInstructions": []
-                        }
-                      ],
-                      "events": []
-                    },
-                    {
-                      "disabled": false,
-                      "folded": false,
-                      "type": "BuiltinCommonInstructions::Standard",
-                      "conditions": [
-                        {
-                          "type": {
-                            "inverted": false,
-                            "value": "KeyPressed"
-                          },
-                          "parameters": [
-                            "",
-                            "Down"
-                          ],
-                          "subInstructions": []
-                        }
-                      ],
-                      "actions": [
-                        {
-                          "type": {
-                            "inverted": false,
-                            "value": "AddForceAL"
-                          },
-                          "parameters": [
-                            "Paddle_2",
-                            "90",
-                            "500",
-                            ""
-                          ],
-                          "subInstructions": []
-                        }
-                      ],
-                      "events": []
+                      "subInstructions": []
                     }
-                  ]
+                  ],
+                  "actions": [
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "AddForceAL"
+                      },
+                      "parameters": [
+                        "Paddle_1",
+                        "90",
+                        "500",
+                        ""
+                      ],
+                      "subInstructions": []
+                    }
+                  ],
+                  "events": []
+                },
+                {
+                  "disabled": false,
+                  "folded": false,
+                  "type": "BuiltinCommonInstructions::Comment",
+                  "color": {
+                    "b": 109,
+                    "g": 230,
+                    "r": 255,
+                    "textB": 0,
+                    "textG": 0,
+                    "textR": 0
+                  },
+                  "comment": "Player 2 movement",
+                  "comment2": ""
+                },
+                {
+                  "disabled": false,
+                  "folded": false,
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "KeyPressed"
+                      },
+                      "parameters": [
+                        "",
+                        "Up"
+                      ],
+                      "subInstructions": []
+                    }
+                  ],
+                  "actions": [
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "AddForceAL"
+                      },
+                      "parameters": [
+                        "Paddle_2",
+                        "-90",
+                        "500",
+                        ""
+                      ],
+                      "subInstructions": []
+                    }
+                  ],
+                  "events": []
+                },
+                {
+                  "disabled": false,
+                  "folded": false,
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "KeyPressed"
+                      },
+                      "parameters": [
+                        "",
+                        "Down"
+                      ],
+                      "subInstructions": []
+                    }
+                  ],
+                  "actions": [
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "AddForceAL"
+                      },
+                      "parameters": [
+                        "Paddle_2",
+                        "90",
+                        "500",
+                        ""
+                      ],
+                      "subInstructions": []
+                    }
+                  ],
+                  "events": []
                 }
               ],
               "parameters": []
@@ -1465,7 +1513,7 @@
                     "textG": 0,
                     "textR": 0
                   },
-                  "comment": "Adapt the texts if we're on a touchscreen",
+                  "comment": "Track the fingers put on the screen (or removed).\nIf a finger is put on a side of the screen, use it to move the appropriate player.",
                   "comment2": ""
                 },
                 {
@@ -1476,7 +1524,7 @@
                     {
                       "type": {
                         "inverted": false,
-                        "value": "SystemInfo::HasTouchScreen"
+                        "value": "HasAnyTouchStarted"
                       },
                       "parameters": [
                         ""
@@ -1488,36 +1536,188 @@
                     {
                       "type": {
                         "inverted": false,
-                        "value": "TextObject::String"
+                        "value": "ModVarScene"
                       },
                       "parameters": [
-                        "PressSpaceText",
+                        "index",
                         "=",
-                        "\"Touch to continue\""
+                        "0"
                       ],
                       "subInstructions": []
-                    },
+                    }
+                  ],
+                  "events": [
+                    {
+                      "disabled": false,
+                      "folded": false,
+                      "type": "BuiltinCommonInstructions::Repeat",
+                      "repeatExpression": "StartedTouchCount()",
+                      "conditions": [],
+                      "actions": [],
+                      "events": [
+                        {
+                          "disabled": false,
+                          "folded": false,
+                          "type": "BuiltinCommonInstructions::Standard",
+                          "conditions": [
+                            {
+                              "type": {
+                                "inverted": false,
+                                "value": "TouchX"
+                              },
+                              "parameters": [
+                                "",
+                                "StartedTouchId(Variable(index))",
+                                "<",
+                                "SceneWindowWidth()/3",
+                                "",
+                                ""
+                              ],
+                              "subInstructions": []
+                            }
+                          ],
+                          "actions": [
+                            {
+                              "type": {
+                                "inverted": false,
+                                "value": "ModVarObjet"
+                              },
+                              "parameters": [
+                                "Paddle_1",
+                                "TouchId",
+                                "=",
+                                "StartedTouchId(Variable(index))"
+                              ],
+                              "subInstructions": []
+                            }
+                          ],
+                          "events": []
+                        },
+                        {
+                          "disabled": false,
+                          "folded": false,
+                          "type": "BuiltinCommonInstructions::Standard",
+                          "conditions": [
+                            {
+                              "type": {
+                                "inverted": false,
+                                "value": "TouchX"
+                              },
+                              "parameters": [
+                                "",
+                                "StartedTouchId(Variable(index))",
+                                ">",
+                                "SceneWindowWidth()*2/3",
+                                "",
+                                ""
+                              ],
+                              "subInstructions": []
+                            }
+                          ],
+                          "actions": [
+                            {
+                              "type": {
+                                "inverted": false,
+                                "value": "ModVarObjet"
+                              },
+                              "parameters": [
+                                "Paddle_2",
+                                "TouchId",
+                                "=",
+                                "StartedTouchId(Variable(index))"
+                              ],
+                              "subInstructions": []
+                            }
+                          ],
+                          "events": []
+                        },
+                        {
+                          "disabled": false,
+                          "folded": false,
+                          "type": "BuiltinCommonInstructions::Standard",
+                          "conditions": [],
+                          "actions": [
+                            {
+                              "type": {
+                                "inverted": false,
+                                "value": "ModVarScene"
+                              },
+                              "parameters": [
+                                "index",
+                                "+",
+                                "1"
+                              ],
+                              "subInstructions": []
+                            }
+                          ],
+                          "events": []
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "disabled": false,
+                  "folded": false,
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [
                     {
                       "type": {
                         "inverted": false,
-                        "value": "TextObject::String"
+                        "value": "HasTouchEnded"
                       },
                       "parameters": [
-                        "Controls_Player2",
-                        "=",
-                        "\"Drag the paddle to move it\""
+                        "",
+                        "Paddle_1.Variable(TouchId)"
                       ],
                       "subInstructions": []
-                    },
+                    }
+                  ],
+                  "actions": [
                     {
                       "type": {
                         "inverted": false,
-                        "value": "TextObject::String"
+                        "value": "ModVarObjet"
                       },
                       "parameters": [
-                        "Controls_Player1",
+                        "Paddle_1",
+                        "TouchId",
                         "=",
-                        "\"Drag the paddle to move it\""
+                        "0"
+                      ],
+                      "subInstructions": []
+                    }
+                  ],
+                  "events": []
+                },
+                {
+                  "disabled": false,
+                  "folded": false,
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "HasTouchEnded"
+                      },
+                      "parameters": [
+                        "",
+                        "Paddle_2.Variable(TouchId)"
+                      ],
+                      "subInstructions": []
+                    }
+                  ],
+                  "actions": [
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "ModVarObjet"
+                      },
+                      "parameters": [
+                        "Paddle_2",
+                        "TouchId",
+                        "=",
+                        "0"
                       ],
                       "subInstructions": []
                     }
@@ -1536,208 +1736,7 @@
                     "textG": 0,
                     "textR": 0
                   },
-                  "comment": "Track the fingers put on the screen (or removed).\nIf a finger is put on a side of the screen, use it to move the appropriate player.",
-                  "comment2": ""
-                },
-                {
-                  "disabled": false,
-                  "folded": false,
-                  "infiniteLoopWarning": true,
-                  "type": "BuiltinCommonInstructions::While",
-                  "whileConditions": [
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "PopStartedTouch"
-                      },
-                      "parameters": [
-                        ""
-                      ],
-                      "subInstructions": []
-                    }
-                  ],
-                  "conditions": [],
-                  "actions": [],
-                  "events": [
-                    {
-                      "disabled": false,
-                      "folded": false,
-                      "type": "BuiltinCommonInstructions::Standard",
-                      "conditions": [
-                        {
-                          "type": {
-                            "inverted": false,
-                            "value": "TouchX"
-                          },
-                          "parameters": [
-                            "",
-                            "LastTouchId()",
-                            "<",
-                            "SceneWindowWidth()/3",
-                            "",
-                            ""
-                          ],
-                          "subInstructions": []
-                        }
-                      ],
-                      "actions": [
-                        {
-                          "type": {
-                            "inverted": false,
-                            "value": "ModVarScene"
-                          },
-                          "parameters": [
-                            "Player1TouchId",
-                            "=",
-                            "LastTouchId()"
-                          ],
-                          "subInstructions": []
-                        }
-                      ],
-                      "events": []
-                    },
-                    {
-                      "disabled": false,
-                      "folded": false,
-                      "type": "BuiltinCommonInstructions::Standard",
-                      "conditions": [
-                        {
-                          "type": {
-                            "inverted": false,
-                            "value": "TouchX"
-                          },
-                          "parameters": [
-                            "",
-                            "LastTouchId()",
-                            ">",
-                            "SceneWindowWidth()*2/3",
-                            "",
-                            ""
-                          ],
-                          "subInstructions": []
-                        }
-                      ],
-                      "actions": [
-                        {
-                          "type": {
-                            "inverted": false,
-                            "value": "ModVarScene"
-                          },
-                          "parameters": [
-                            "Player2TouchId",
-                            "=",
-                            "LastTouchId()"
-                          ],
-                          "subInstructions": []
-                        }
-                      ],
-                      "events": []
-                    }
-                  ]
-                },
-                {
-                  "disabled": false,
-                  "folded": false,
-                  "infiniteLoopWarning": true,
-                  "type": "BuiltinCommonInstructions::While",
-                  "whileConditions": [
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "PopEndedTouch"
-                      },
-                      "parameters": [
-                        ""
-                      ],
-                      "subInstructions": []
-                    }
-                  ],
-                  "conditions": [],
-                  "actions": [],
-                  "events": [
-                    {
-                      "disabled": false,
-                      "folded": false,
-                      "type": "BuiltinCommonInstructions::Standard",
-                      "conditions": [
-                        {
-                          "type": {
-                            "inverted": false,
-                            "value": "VarScene"
-                          },
-                          "parameters": [
-                            "Player1TouchId",
-                            "=",
-                            "LastEndedTouchId()"
-                          ],
-                          "subInstructions": []
-                        }
-                      ],
-                      "actions": [
-                        {
-                          "type": {
-                            "inverted": false,
-                            "value": "ModVarScene"
-                          },
-                          "parameters": [
-                            "Player1TouchId",
-                            "=",
-                            "-1"
-                          ],
-                          "subInstructions": []
-                        }
-                      ],
-                      "events": []
-                    },
-                    {
-                      "disabled": false,
-                      "folded": false,
-                      "type": "BuiltinCommonInstructions::Standard",
-                      "conditions": [
-                        {
-                          "type": {
-                            "inverted": false,
-                            "value": "VarScene"
-                          },
-                          "parameters": [
-                            "Player2TouchId",
-                            "=",
-                            "LastEndedTouchId()"
-                          ],
-                          "subInstructions": []
-                        }
-                      ],
-                      "actions": [
-                        {
-                          "type": {
-                            "inverted": false,
-                            "value": "ModVarScene"
-                          },
-                          "parameters": [
-                            "Player2TouchId",
-                            "=",
-                            "-1"
-                          ],
-                          "subInstructions": []
-                        }
-                      ],
-                      "events": []
-                    }
-                  ]
-                },
-                {
-                  "disabled": false,
-                  "folded": false,
-                  "type": "BuiltinCommonInstructions::Comment",
-                  "color": {
-                    "b": 109,
-                    "g": 230,
-                    "r": 255,
-                    "textB": 0,
-                    "textG": 0,
-                    "textR": 0
-                  },
-                  "comment": "When we know the player finger identifier, use it set the the paddle position. \n-1 means that there is no finger for the player.",
+                  "comment": "When we know the player finger identifier, use it set the the paddle position. \n0 means that there is no finger for the player.",
                   "comment2": ""
                 },
                 {
@@ -1748,12 +1747,13 @@
                     {
                       "type": {
                         "inverted": false,
-                        "value": "VarScene"
+                        "value": "VarObjet"
                       },
                       "parameters": [
-                        "Player1TouchId",
+                        "Paddle_1",
+                        "TouchId",
                         "!=",
-                        "-1"
+                        "0"
                       ],
                       "subInstructions": []
                     }
@@ -1767,7 +1767,7 @@
                       "parameters": [
                         "Paddle_1",
                         "=",
-                        "TouchY(Variable(Player1TouchId))"
+                        "TouchY(Paddle_1.Variable(TouchId))"
                       ],
                       "subInstructions": []
                     }
@@ -1782,12 +1782,13 @@
                     {
                       "type": {
                         "inverted": false,
-                        "value": "VarScene"
+                        "value": "VarObjet"
                       },
                       "parameters": [
-                        "Player2TouchId",
+                        "Paddle_2",
+                        "TouchId",
                         "!=",
-                        "-1"
+                        "0"
                       ],
                       "subInstructions": []
                     }
@@ -1801,7 +1802,7 @@
                       "parameters": [
                         "Paddle_2",
                         "=",
-                        "TouchY(Variable(Player2TouchId))"
+                        "TouchY(Paddle_2.Variable(TouchId))"
                       ],
                       "subInstructions": []
                     }
@@ -2222,6 +2223,18 @@
                 {
                   "type": {
                     "inverted": false,
+                    "value": "TextObject::String"
+                  },
+                  "parameters": [
+                    "Player_2_Score",
+                    "=",
+                    "VariableString(player2Score)"
+                  ],
+                  "subInstructions": []
+                },
+                {
+                  "type": {
+                    "inverted": false,
                     "value": "Arreter"
                   },
                   "parameters": [
@@ -2483,6 +2496,18 @@
                 {
                   "type": {
                     "inverted": false,
+                    "value": "TextObject::String"
+                  },
+                  "parameters": [
+                    "Player_1_Score",
+                    "=",
+                    "VariableString(player1Score)"
+                  ],
+                  "subInstructions": []
+                },
+                {
+                  "type": {
+                    "inverted": false,
                     "value": "Arreter"
                   },
                   "parameters": [
@@ -2705,39 +2730,6 @@
               },
               "comment": "The gui elements are anchored using the anchor behavior",
               "comment2": ""
-            },
-            {
-              "disabled": false,
-              "folded": false,
-              "type": "BuiltinCommonInstructions::Standard",
-              "conditions": [],
-              "actions": [
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "TextObject::String"
-                  },
-                  "parameters": [
-                    "Player_1_Score",
-                    "=",
-                    "VariableString(player1Score)"
-                  ],
-                  "subInstructions": []
-                },
-                {
-                  "type": {
-                    "inverted": false,
-                    "value": "TextObject::String"
-                  },
-                  "parameters": [
-                    "Player_2_Score",
-                    "=",
-                    "VariableString(player2Score)"
-                  ],
-                  "subInstructions": []
-                }
-              ],
-              "events": []
             },
             {
               "disabled": false,
@@ -3626,6 +3618,7 @@
   "eventsFunctionsExtensions": [
     {
       "author": "@4ian",
+      "category": "",
       "description": "Provides an action to make the object bounce from another object it just touched. Add a permanent force to the object and, when in collision with another one, use the action to make it bounce realistically.\n\nThere are also actions to bounce at a *specific angle* - useful when you know the obstacle must generate a bounce that is always in a specific direction.\n\n> ⚠️ This *won't work* with Physics engine or Platformer characters. This is working with objects that are moved using actions or behaviors using **the forces**.",
       "extensionNamespace": "",
       "fullName": "Bounce (using forces)",
@@ -3653,6 +3646,7 @@
               "description": "Bounce the object off another object it is currently colliding with, according to the angle and the speed of forces applied on the object.\nMake sure to test for a collision between the two objects before launching this action. All the forces will be removed from the object, and a new permanent force will be added to make the object bounce.",
               "fullName": "Bounce off another object",
               "functionType": "Action",
+              "group": "",
               "name": "BounceOff",
               "private": false,
               "sentence": "Bounce _PARAM0_ off _PARAM2_",
@@ -3864,6 +3858,7 @@
               "description": "Bounce the object off another object it is currently colliding with, according to the angle and the speed of forces applied on the object.\nThe bounce will always be calculated *to go toward the specified angle (the \"normal angle\")*. For example, if the object is arriving at this exact angle, it will bounce in the opposite direction.\n\nMake sure to test for a collision between the two objects before launching this action. All the forces will be removed from the object, and a new permanent force will be added to make the object bounce.",
               "fullName": "Bounce off another object toward a specified angle",
               "functionType": "Action",
+              "group": "",
               "name": "BounceOffSpecificAngle",
               "private": false,
               "sentence": "Bounce _PARAM0_ off _PARAM2_ assuming a normal angle of _PARAM3_",
@@ -4085,6 +4080,7 @@
               "description": "Bounce the object off another object it is currently colliding with, according to the angle and the speed of forces applied on the object.\nThe bounce will always be vertical, like if the object is *colliding a perfectly horizontal obstacle* (like the top/bottom of the screen in a pong game). For example, if the object is arriving with an angle of exactly 90 degrees, it will bounce in the opposite direction: -90 degrees.\n\nMake sure to test for a collision between the two objects before launching this action. All the forces will be removed from the object, and a new permanent force will be added to make the object bounce.",
               "fullName": "Bounce vertically",
               "functionType": "Action",
+              "group": "",
               "name": "BounceOffVertically",
               "private": false,
               "sentence": "Bounce _PARAM0_ off _PARAM2_ - always vertically",
@@ -4151,6 +4147,7 @@
               "description": "Bounce the object off another object it is currently colliding with, according to the angle and the speed of forces applied on the object.\nThe bounce will always be horizontal, like if the object is *colliding a perfectly vertical obstacle* (like paddles in a pong game). For example, if the object is arriving with an angle of exactly 0 degrees, it will bounce in the opposite direction: 180 degrees.\n\nMake sure to test for a collision between the two objects before launching this action. All the forces will be removed from the object, and a new permanent force will be added to make the object bounce.",
               "fullName": "Bounce horizontally",
               "functionType": "Action",
+              "group": "",
               "name": "BounceOffHorizontally",
               "private": false,
               "sentence": "Bounce _PARAM0_ off _PARAM2_ - always horizontally",
@@ -4220,6 +4217,7 @@
               "type": "Number",
               "label": "",
               "description": "",
+              "group": "",
               "extraInformation": [],
               "hidden": true,
               "name": "OldX"
@@ -4229,6 +4227,7 @@
               "type": "Number",
               "label": "",
               "description": "",
+              "group": "",
               "extraInformation": [],
               "hidden": true,
               "name": "OldY"
@@ -4238,6 +4237,7 @@
               "type": "Number",
               "label": "",
               "description": "",
+              "group": "",
               "extraInformation": [],
               "hidden": true,
               "name": "OldForceAngle"
@@ -4247,6 +4247,7 @@
               "type": "Number",
               "label": "",
               "description": "",
+              "group": "",
               "extraInformation": [],
               "hidden": true,
               "name": "OldForceLength"
@@ -4256,6 +4257,7 @@
               "type": "Number",
               "label": "",
               "description": "",
+              "group": "",
               "extraInformation": [],
               "hidden": true,
               "name": "NormalAngle"


### PR DESCRIPTION
This should not be merged before the release of GDevelop 5.0.132 as it won't work with the current version.

There is no control over the ball direction. The classic pong uses the speed of the paddle. It might be too tiny on a smartphone to do the same. Otherwise, what was done for the breakout example could be applied here.

* Build: https://liluo.io/d8h/ping-pong
* Project: https://www.dropbox.com/s/anxnlu8tirg1w3u/multitouch.zip?dl=1

It can be reviewed with the nightly:
* https://github.com/4ian/GDevelop/blob/master/newIDE/docs/Nightly-Builds-and-continuous-deployment.md