### PR TITLE
[platformer-with-tilemap] Fix the pixel size value of the pixel-perfect behavior.

### DIFF
--- a/examples/platformer-with-tilemap/platformer-with-tilemap.json
+++ b/examples/platformer-with-tilemap/platformer-with-tilemap.json
@@ -657,7 +657,7 @@
               "name": "PixelPerfectPlatformerCharacter",
               "type": "PixelPerfectMovement::PixelPerfectPlatformerCharacter",
               "PlatformerCharacter": "PlatformerObject",
-              "PixelSize": 4,
+              "PixelSize": 1,
               "OffsetX": 0,
               "OffsetY": 0,
               "TargetX": 0,


### PR DESCRIPTION
Otherwise, the character moved 4 pixels per 4 pixels.