### PR TITLE
Platformer updates based on user feedback (v1.2.1)

### DIFF
--- a/examples/platformer/platformer.json
+++ b/examples/platformer/platformer.json
@@ -16,9 +16,9 @@
     "scaleMode": "linear",
     "sizeOnStartupMode": "adaptWidth",
     "useExternalSourceFiles": false,
-    "version": "1.2.0",
+    "version": "1.2.1",
     "name": "Platformer",
-    "description": "",
+    "description": "An example of a basic platformer (Mario-like) game. Jump around and collect as many coins as you can!",
     "author": "",
     "windowWidth": 960,
     "windowHeight": 540,
@@ -905,7 +905,7 @@
         "gridColor": 10401023,
         "gridAlpha": 0.8,
         "snap": false,
-        "zoomFactor": 0.9701844970703115,
+        "zoomFactor": 0.4901844970703111,
         "windowMask": false
       },
       "objectsGroups": [
@@ -960,6 +960,23 @@
             },
             {
               "name": "EndScreenRetryText"
+            }
+          ]
+        },
+        {
+          "name": "HelperObjects",
+          "objects": [
+            {
+              "name": "LeftBoundary"
+            },
+            {
+              "name": "RightBoundary"
+            },
+            {
+              "name": "BoundaryJumpThrough"
+            },
+            {
+              "name": "PlayerSpawn"
             }
           ]
         }
@@ -1040,7 +1057,7 @@
           "angle": 45,
           "customSize": true,
           "height": 35.13332748413086,
-          "layer": "HelperObjects",
+          "layer": "",
           "locked": false,
           "name": "PlayerSpawn",
           "persistentUuid": "d7bd5b19-978f-4986-ba80-bb4b0ba3d208",
@@ -1104,11 +1121,11 @@
           "angle": 0,
           "customSize": true,
           "height": 78,
-          "layer": "Clouds",
+          "layer": "",
           "locked": false,
           "name": "Clouds",
           "persistentUuid": "7a4f19b7-6962-4686-9bfa-69dd5158902c",
-          "width": 1297,
+          "width": 2272,
           "x": 0,
           "y": 472,
           "zOrder": 36,
@@ -1119,31 +1136,15 @@
         {
           "angle": 0,
           "customSize": true,
-          "height": 712,
-          "layer": "HelperObjects",
+          "height": 928,
+          "layer": "",
           "locked": false,
-          "name": "Boundary",
+          "name": "LeftBoundary",
           "persistentUuid": "78dd0ffa-b22f-47a8-9b36-ef6a432b1d1e",
           "width": 135,
-          "x": 1,
-          "y": -138,
+          "x": 0,
+          "y": -256,
           "zOrder": 38,
-          "numberProperties": [],
-          "stringProperties": [],
-          "initialVariables": []
-        },
-        {
-          "angle": 0,
-          "customSize": true,
-          "height": 736,
-          "layer": "HelperObjects",
-          "locked": false,
-          "name": "Boundary",
-          "persistentUuid": "50e818c5-d494-429b-8627-2ccc2b120908",
-          "width": 73,
-          "x": 2182,
-          "y": -175,
-          "zOrder": 39,
           "numberProperties": [],
           "stringProperties": [],
           "initialVariables": []
@@ -1365,7 +1366,7 @@
           "angle": 0,
           "customSize": true,
           "height": 21,
-          "layer": "HelperObjects",
+          "layer": "",
           "locked": false,
           "name": "BoundaryJumpThrough",
           "persistentUuid": "7483dc27-84ed-436f-9611-ea3d03ec6df8",
@@ -1577,7 +1578,7 @@
           "locked": false,
           "name": "BackgroundPlants",
           "persistentUuid": "03b6869d-198f-4807-b659-f2b863e21073",
-          "width": 1767,
+          "width": 2272,
           "x": 0,
           "y": -25,
           "zOrder": -1,
@@ -1645,6 +1646,54 @@
           "x": 64,
           "y": 352,
           "zOrder": 57,
+          "numberProperties": [],
+          "stringProperties": [],
+          "initialVariables": []
+        },
+        {
+          "angle": 0,
+          "customSize": true,
+          "height": 928,
+          "layer": "",
+          "locked": false,
+          "name": "RightBoundary",
+          "persistentUuid": "9562fd9d-6e93-4465-9013-efa2b833653b",
+          "width": 160,
+          "x": 2112,
+          "y": -256,
+          "zOrder": 58,
+          "numberProperties": [],
+          "stringProperties": [],
+          "initialVariables": []
+        },
+        {
+          "angle": 0,
+          "customSize": true,
+          "height": 128,
+          "layer": "",
+          "locked": false,
+          "name": "TopBoundary",
+          "persistentUuid": "4381c067-2682-4f00-9a24-ff28fa12b1d8",
+          "width": 2272,
+          "x": 0,
+          "y": -256,
+          "zOrder": 59,
+          "numberProperties": [],
+          "stringProperties": [],
+          "initialVariables": []
+        },
+        {
+          "angle": 0,
+          "customSize": true,
+          "height": 128,
+          "layer": "",
+          "locked": false,
+          "name": "BottomBoundary",
+          "persistentUuid": "00f86cf3-18b0-4d71-9ce8-952dfc4e6b5c",
+          "width": 2272,
+          "x": 0,
+          "y": 544,
+          "zOrder": 60,
           "numberProperties": [],
           "stringProperties": [],
           "initialVariables": []
@@ -5971,7 +6020,7 @@
           "behaviors": []
         },
         {
-          "name": "Boundary",
+          "name": "LeftBoundary",
           "tags": "",
           "type": "Sprite",
           "updateIfNotVisible": false,
@@ -5986,6 +6035,134 @@
               "yGrabOffset": 0
             }
           ],
+          "animations": [
+            {
+              "name": "",
+              "useMultipleDirections": false,
+              "directions": [
+                {
+                  "looping": false,
+                  "timeBetweenFrames": 0.08,
+                  "sprites": [
+                    {
+                      "hasCustomCollisionMask": false,
+                      "image": "assets\\boundary.png",
+                      "points": [],
+                      "originPoint": {
+                        "name": "origine",
+                        "x": 0,
+                        "y": 0
+                      },
+                      "centerPoint": {
+                        "automatic": true,
+                        "name": "centre",
+                        "x": 0,
+                        "y": 0
+                      },
+                      "customCollisionMask": []
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "RightBoundary",
+          "tags": "",
+          "type": "Sprite",
+          "updateIfNotVisible": false,
+          "variables": [],
+          "effects": [],
+          "behaviors": [
+            {
+              "name": "Platform",
+              "type": "PlatformBehavior::PlatformBehavior",
+              "canBeGrabbed": false,
+              "platformType": "NormalPlatform",
+              "yGrabOffset": 0
+            }
+          ],
+          "animations": [
+            {
+              "name": "",
+              "useMultipleDirections": false,
+              "directions": [
+                {
+                  "looping": false,
+                  "timeBetweenFrames": 0.08,
+                  "sprites": [
+                    {
+                      "hasCustomCollisionMask": false,
+                      "image": "assets\\boundary.png",
+                      "points": [],
+                      "originPoint": {
+                        "name": "origine",
+                        "x": 0,
+                        "y": 0
+                      },
+                      "centerPoint": {
+                        "automatic": true,
+                        "name": "centre",
+                        "x": 0,
+                        "y": 0
+                      },
+                      "customCollisionMask": []
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "TopBoundary",
+          "tags": "",
+          "type": "Sprite",
+          "updateIfNotVisible": false,
+          "variables": [],
+          "effects": [],
+          "behaviors": [],
+          "animations": [
+            {
+              "name": "",
+              "useMultipleDirections": false,
+              "directions": [
+                {
+                  "looping": false,
+                  "timeBetweenFrames": 0.08,
+                  "sprites": [
+                    {
+                      "hasCustomCollisionMask": false,
+                      "image": "assets\\boundary.png",
+                      "points": [],
+                      "originPoint": {
+                        "name": "origine",
+                        "x": 0,
+                        "y": 0
+                      },
+                      "centerPoint": {
+                        "automatic": true,
+                        "name": "centre",
+                        "x": 0,
+                        "y": 0
+                      },
+                      "customCollisionMask": []
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "BottomBoundary",
+          "tags": "",
+          "type": "Sprite",
+          "updateIfNotVisible": false,
+          "variables": [],
+          "effects": [],
+          "behaviors": [],
           "animations": [
             {
               "name": "",
@@ -8969,28 +9146,13 @@
                         {
                           "type": {
                             "inverted": false,
-                            "value": "Tween::AddObjectPositionXTween"
+                            "value": "Tween::AddObjectPositionTween"
                           },
                           "parameters": [
                             "Player",
                             "Tween",
-                            "\"IntoPortalX\"",
+                            "\"MoveIntoPortal\"",
                             "Portal.CenterX() + Player.Width() / 2",
-                            "\"linear\"",
-                            "1000",
-                            "no"
-                          ],
-                          "subInstructions": []
-                        },
-                        {
-                          "type": {
-                            "inverted": false,
-                            "value": "Tween::AddObjectPositionYTween"
-                          },
-                          "parameters": [
-                            "Player",
-                            "Tween",
-                            "\"IntoPortalY\"",
                             "Portal.CenterY()",
                             "\"linear\"",
                             "1000",
@@ -9006,7 +9168,7 @@
                           "parameters": [
                             "Player",
                             "Tween",
-                            "\"IntoPortalRotate\"",
+                            "\"RotateIntoPortal\"",
                             "360",
                             "\"linear\"",
                             "1000",
@@ -9041,7 +9203,7 @@
                           "parameters": [
                             "Player",
                             "Tween",
-                            "\"IntoPortalRotate\""
+                            "\"RotateIntoPortal\""
                           ],
                           "subInstructions": []
                         },
@@ -9063,7 +9225,7 @@
                           "parameters": [
                             "Player",
                             "Tween",
-                            "\"IntoPortalShrink\"",
+                            "\"ShrinkIntoPortal\"",
                             "0",
                             "0",
                             "\"linear\"",
@@ -9477,6 +9639,47 @@
               "events": [
                 {
                   "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "DepartScene"
+                      },
+                      "parameters": [
+                        ""
+                      ],
+                      "subInstructions": []
+                    }
+                  ],
+                  "actions": [
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "Cache"
+                      },
+                      "parameters": [
+                        "HelperObjects"
+                      ],
+                      "subInstructions": []
+                    }
+                  ],
+                  "events": []
+                },
+                {
+                  "type": "BuiltinCommonInstructions::Comment",
+                  "color": {
+                    "b": 109,
+                    "g": 230,
+                    "r": 255,
+                    "textB": 0,
+                    "textG": 0,
+                    "textR": 0
+                  },
+                  "comment": "Boundary objects act like invisible walls for the player and they also define where the camera can move.",
+                  "comment2": ""
+                },
+                {
+                  "type": "BuiltinCommonInstructions::Standard",
                   "conditions": [],
                   "actions": [
                     {
@@ -9491,10 +9694,10 @@
                         "0.05",
                         "",
                         "",
-                        "124",
-                        "-120",
-                        "2113",
-                        "542",
+                        "LeftBoundary.BoundingBoxRight()",
+                        "TopBoundary.BoundingBoxBottom()",
+                        "RightBoundary.BoundingBoxLeft()",
+                        "BottomBoundary.BoundingBoxTop()",
                         ""
                       ],
                       "subInstructions": []
@@ -9569,18 +9772,6 @@
                         "value": "TiledSpriteObject::Width"
                       },
                       "parameters": [
-                        "Clouds",
-                        "=",
-                        "CameraWidth(\"\",0)"
-                      ],
-                      "subInstructions": []
-                    },
-                    {
-                      "type": {
-                        "inverted": false,
-                        "value": "TiledSpriteObject::Width"
-                      },
-                      "parameters": [
                         "BackgroundPlants",
                         "=",
                         "CameraWidth(\"\",0)"
@@ -9602,12 +9793,36 @@
                     {
                       "type": {
                         "inverted": false,
+                        "value": "MettreX"
+                      },
+                      "parameters": [
+                        "Clouds",
+                        "=",
+                        "CameraX() - CameraWidth(\"\",0)/2"
+                      ],
+                      "subInstructions": []
+                    },
+                    {
+                      "type": {
+                        "inverted": false,
+                        "value": "TiledSpriteObject::Width"
+                      },
+                      "parameters": [
+                        "Clouds",
+                        "=",
+                        "CameraWidth(\"\",0)"
+                      ],
+                      "subInstructions": []
+                    },
+                    {
+                      "type": {
+                        "inverted": false,
                         "value": "TiledSpriteObject::XOffset"
                       },
                       "parameters": [
                         "Clouds",
                         "=",
-                        "CameraX()*1.5"
+                        "CameraX()*1.2"
                       ],
                       "subInstructions": []
                     }
@@ -9767,28 +9982,6 @@
               "width": 0
             }
           ],
-          "effects": []
-        },
-        {
-          "ambientLightColorB": 100663296,
-          "ambientLightColorG": 6031360,
-          "ambientLightColorR": 7502112,
-          "followBaseLayerCamera": false,
-          "isLightingLayer": false,
-          "name": "Clouds",
-          "visibility": true,
-          "cameras": [],
-          "effects": []
-        },
-        {
-          "ambientLightColorB": -2147483632,
-          "ambientLightColorG": 6031360,
-          "ambientLightColorR": 7867696,
-          "followBaseLayerCamera": false,
-          "isLightingLayer": false,
-          "name": "HelperObjects",
-          "visibility": false,
-          "cameras": [],
           "effects": []
         },
         {


### PR DESCRIPTION
Reported problems:

- When trying to add more objects to the level, users were confused by the hidden boundary objects which act like a hidden wall (due to platform behavior)

- Users have to manually update positions for camera limits when growing the level

Changes:

- Added Top/Bottom/Left/Right boundary objects
- Changed camera limits to use boundary objects (users can simply move these to change the size of the level)
- Added HelperObjects group and hide them at the beginning of scene (so users will see them in scene editor)

Other improvements:

- Stopped clouds from moving on Y
- Removed "Clouds" and "HelperObjects" layers
- Combined X and Y tween into single tween

## Playable game
https://games.gdevelop-app.com/game-5aef0c16-f8fb-40e7-b93c-09375a9257bb/index.html

## Screenshots

![Screenshot 2022-05-17 103444](https://user-images.githubusercontent.com/8879811/168870245-e61d3ee5-1f92-4472-9f6b-23b125a72b01.png)
![Screenshot 2022-05-17 103600](https://user-images.githubusercontent.com/8879811/168870248-08d17d75-ea73-49e9-aee2-4138d790defc.png)

