### PR TITLE
Health bar fix for GunDude desktop version

### DIFF
--- a/examples/conviction-of-gun-dude-desktop/conviction-of-gun-dude-desktop.json
+++ b/examples/conviction-of-gun-dude-desktop/conviction-of-gun-dude-desktop.json
@@ -19897,7 +19897,7 @@
               "parameters": [
                 "HealthBar",
                 "=",
-                "clamp(0,(HealthBar.Width()*(Wesley.Health::Health()/Variable(CharacterStats.Health))), HealthBar.Width())"
+                "clamp(0,(216*(Wesley.Health::Health()/Variable(CharacterStats.Health))), 216)"
               ],
               "subInstructions": []
             },


### PR DESCRIPTION
The healthbar display wasn't working right with the HealthBar.Width().

So I replaced it with the pixel width of the health bar when at 100% size. The number 216 is explained in the comment above this event, so people will hopefully not be confused by it if they want to alter it themselves in the future.

@Bouh This is just a quick fix for the health bar. 👍