### PR TITLE
[platformer-with-tilemap] Add a linear camera following.

### DIFF
--- a/examples/platformer-with-tilemap/platformer-with-tilemap.json
+++ b/examples/platformer-with-tilemap/platformer-with-tilemap.json
@@ -18,8 +18,8 @@
     "templateSlug": "",
     "useExternalSourceFiles": false,
     "version": "1.0.0",
-    "name": "Platformer With TImemap",
-    "description": "",
+    "name": "Platformer with tile map",
+    "description": "Shows how to create a pixel-perfect platformer game with a Tilemap object for designing the level.",
     "author": "",
     "windowWidth": 200,
     "windowHeight": 150,
@@ -44,7 +44,9 @@
       "showGDevelopSplash": true,
       "showProgressBar": true
     },
-    "authorIds": [],
+    "authorIds": [
+      "IWykYNRvhCZBN3vEgKEbBPOR3Oc2"
+    ],
     "categories": [],
     "playableDevices": [
       "keyboard"
@@ -270,22 +272,92 @@
               "TargetDirectionY": 0
             },
             {
+              "gravity": 250,
+              "jumpSpeed": 150,
+              "jumpSustainTime": 0.2,
+              "maxFallingSpeed": 200,
               "name": "PlatformerObject",
               "type": "PlatformBehavior::PlatformerObjectBehavior",
-              "jumpSpeed": 200,
-              "ladderClimbingSpeed": 50,
-              "maxFallingSpeed": 300,
+              "ladderClimbingSpeed": 100,
+              "yGrabOffset": 0,
               "maxSpeed": 100,
               "acceleration": 400,
               "canGrabPlatforms": false,
               "deceleration": 400,
-              "gravity": 600,
               "ignoreDefaultControls": false,
-              "jumpSustainTime": 0.2,
               "roundCoordinates": true,
               "slopeMaxAngle": 60,
-              "xGrabTolerance": 10,
-              "yGrabOffset": 0
+              "xGrabTolerance": 10
+            },
+            {
+              "name": "SmoothCamera",
+              "type": "SmoothCamera::SmoothCamera",
+              "LeftwardSpeed": 1,
+              "RightwardSpeed": 1,
+              "UpwardSpeed": 1,
+              "DownwardSpeed": 1,
+              "FollowOnX": true,
+              "FollowOnY": true,
+              "FollowFreeAreaLeft": 0,
+              "FollowFreeAreaRight": 0,
+              "FollowFreeAreaTop": 12,
+              "FollowFreeAreaBottom": 12,
+              "CameraOffsetX": 0,
+              "CameraOffsetY": 0,
+              "CameraDelay": 0,
+              "ForecastTime": 0,
+              "ForecastHistoryDuration": 0,
+              "LogLeftwardSpeed": 0,
+              "LogRightwardSpeed": 0,
+              "LogDownwardSpeed": 0,
+              "LogUpwardSpeed": 0,
+              "DelayedCenterX": 0,
+              "DelayedCenterY": 0,
+              "ForecastHistoryMeanX": 0,
+              "ForecastHistoryMeanY": 0,
+              "ForecastHistoryVarianceX": 0,
+              "ForecastHistoryCovariance": 0,
+              "ForecastHistoryLinearA": 0,
+              "ForecastHistoryLinearB": 0,
+              "ForecastedX": 0,
+              "ForecastedY": 0,
+              "ProjectedNewestX": 0,
+              "ProjectedNewestY": 0,
+              "ProjectedOldestX": 0,
+              "ProjectedOldestY": 0,
+              "ForecastHistoryVarianceY": 0,
+              "Index": 0,
+              "CameraDelayCatchUpSpeed": 0,
+              "CameraExtraDelay": 0,
+              "WaitingSpeedXMax": 0,
+              "WaitingSpeedYMax": 0,
+              "WaitingEnd": 0,
+              "CameraDelayCatchUpDuration": 0,
+              "LeftwardSpeedMax": 9000,
+              "RightwardSpeedMax": 9000,
+              "UpwardSpeedMax": 150,
+              "DownwardSpeedMax": 200,
+              "OldX": 0,
+              "OldY": 0
+            },
+            {
+              "name": "SmoothPlatformerCamera",
+              "type": "SmoothCamera::SmoothPlatformerCamera",
+              "PlatformerCharacter": "PlatformerObject",
+              "SmoothCamera": "SmoothCamera",
+              "JumpOriginY": 0,
+              "AirFollowFreeAreaTop": 12,
+              "AirFollowFreeAreaBottom": 12,
+              "FloorFollowFreeAreaTop": 0,
+              "FloorFollowFreeAreaBottom": 0,
+              "AirUpwardSpeed": 1,
+              "AirDownwardSpeed": 1,
+              "FloorUpwardSpeed": 1,
+              "FloorDownwardSpeed": 1,
+              "AirUpwardSpeedMax": 150,
+              "AirDownwardSpeedMax": 200,
+              "FloorUpwardSpeedMax": 150,
+              "FloorDownwardSpeedMax": 180
             }
           ],
           "animations": [
@@ -416,7 +488,7 @@
             "textG": 0,
             "textR": 0
           },
-          "comment": "We use Tile Map Collision Mask objects to specify which tiles are platforms/ladder/jump thrus.\nThe tilemap object should be edited in Tiled, an external level editor that can be downloaded on mapeditor.org.\n\nThe character has a behavior to stop perfectly on a pixel and yet move smoothly.",
+          "comment": "We use Tile Map Collision Mask objects to specify which tiles are platforms, ladder or jump thrus.\nThe tilemap object should be edited in Tiled, an external level editor that can be downloaded on mapeditor.org.\n\nThe character has a behavior to stop perfectly on a pixel and yet move smoothly.",
           "comment2": ""
         },
         {
@@ -487,8 +559,37 @@
           ]
         },
         {
+          "type": "BuiltinCommonInstructions::Comment",
+          "color": {
+            "b": 109,
+            "g": 230,
+            "r": 255,
+            "textB": 0,
+            "textG": 0,
+            "textR": 0
+          },
+          "comment": "Center the camera on the player at the 2nd frame, after the windows size has changed.\nThis avoids a camera movement at the beginning.\n\nThe SmoothCamera extension will keep the camera centered on the Hero afterward.",
+          "comment2": ""
+        },
+        {
           "type": "BuiltinCommonInstructions::Standard",
-          "conditions": [],
+          "conditions": [
+            {
+              "type": {
+                "inverted": true,
+                "value": "DepartScene"
+              },
+              "parameters": [
+                ""
+              ]
+            },
+            {
+              "type": {
+                "value": "BuiltinCommonInstructions::Once"
+              },
+              "parameters": []
+            }
+          ],
           "actions": [
             {
               "type": {
@@ -524,6 +625,59 @@
                 "",
                 "\"Collision\"",
                 "0"
+              ]
+            }
+          ]
+        },
+        {
+          "type": "BuiltinCommonInstructions::Comment",
+          "color": {
+            "b": 109,
+            "g": 230,
+            "r": 255,
+            "textB": 0,
+            "textG": 0,
+            "textR": 0
+          },
+          "comment": "There is 3 layers to move and the SmoothCamera only move the one of the Hero.\nThe CopyCameraSettings is used to move the 2 other cameras accordingly.",
+          "comment2": ""
+        },
+        {
+          "type": "BuiltinCommonInstructions::Standard",
+          "conditions": [],
+          "actions": [
+            {
+              "type": {
+                "value": "CopyCameraSettings::CopyCameraSettings"
+              },
+              "parameters": [
+                "",
+                "\"\"",
+                "0",
+                "\"TileMap\"",
+                "0",
+                "",
+                "",
+                "no",
+                "no",
+                ""
+              ]
+            },
+            {
+              "type": {
+                "value": "CopyCameraSettings::CopyCameraSettings"
+              },
+              "parameters": [
+                "",
+                "\"\"",
+                "0",
+                "\"Collision\"",
+                "0",
+                "",
+                "",
+                "no",
+                "no",
+                ""
               ]
             }
           ]
@@ -587,12 +741,5809 @@
         {
           "name": "PlatformerObject",
           "type": "PlatformBehavior::PlatformerObjectBehavior"
+        },
+        {
+          "name": "SmoothCamera",
+          "type": "SmoothCamera::SmoothCamera"
+        },
+        {
+          "name": "SmoothPlatformerCamera",
+          "type": "SmoothCamera::SmoothPlatformerCamera"
         }
       ]
     }
   ],
   "externalEvents": [],
   "eventsFunctionsExtensions": [
+    {
+      "author": "",
+      "category": "",
+      "description": "Useful when multiple layers need to use the same camera values.\n\nHow to use:\n- Run the \"Copy camera settings\" action after all other camera actions have been performed\n\nTips:\n- Do not use on layers that implement a parallax effect",
+      "extensionNamespace": "",
+      "fullName": "Copy camera settings",
+      "helpPath": "",
+      "iconUrl": "data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz48IURPQ1RZUEUgc3ZnIFBVQkxJQyAiLS8vVzNDLy9EVEQgU1ZHIDEuMS8vRU4iICJodHRwOi8vd3d3LnczLm9yZy9HcmFwaGljcy9TVkcvMS4xL0RURC9zdmcxMS5kdGQiPjxzdmcgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB4bWxuczp4bGluaz0iaHR0cDovL3d3dy53My5vcmcvMTk5OS94bGluayIgdmVyc2lvbj0iMS4xIiBpZD0ibWRpLWxheWVycy10cmlwbGUtb3V0bGluZSIgd2lkdGg9IjI0IiBoZWlnaHQ9IjI0IiB2aWV3Qm94PSIwIDAgMjQgMjQiPjxwYXRoIGQ9Ik0xMiAxNi41NEwxOS4zNyAxMC44TDIxIDEyLjA3TDEyIDE5LjA3TDMgMTIuMDdMNC42MiAxMC44MUwxMiAxNi41NE0xMiAxNEwzIDdMMTIgMEwyMSA3TDEyIDE0TTEyIDIuNTNMNi4yNiA3TDEyIDExLjQ3TDE3Ljc0IDdMMTIgMi41M00xMiAyMS40N0wxOS4zNyAxNS43M0wyMSAxN0wxMiAyNEwzIDE3TDQuNjIgMTUuNzRMMTIgMjEuNDciIC8+PC9zdmc+",
+      "name": "CopyCameraSettings",
+      "previewIconUrl": "https://resources.gdevelop-app.com/assets/Icons/layers-triple-outline.svg",
+      "shortDescription": "Copy the camera settings of a layer and apply them to another layer.",
+      "version": "1.0.0",
+      "origin": {
+        "identifier": "CopyCameraSettings",
+        "name": "gdevelop-extension-store"
+      },
+      "tags": [
+        "camera",
+        "clone",
+        "zoom",
+        "position",
+        "layer",
+        "angle",
+        "copy"
+      ],
+      "authorIds": [
+        "gqDaZjCfevOOxBYkK6zlhtZnXCg1"
+      ],
+      "dependencies": [],
+      "eventsFunctions": [
+        {
+          "description": "Copy camera settings of a layer and apply them to another layer.",
+          "fullName": "Copy camera settings",
+          "functionType": "Action",
+          "group": "",
+          "name": "CopyCameraSettings",
+          "private": false,
+          "sentence": "Copy camera settings of _PARAM1_ layer and apply them to _PARAM3_ layer (X position: _PARAM5_, Y position: _PARAM6_, Zoom: _PARAM7_,  Angle: _PARAM8_)",
+          "events": [
+            {
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "value": "GetArgumentAsBoolean"
+                  },
+                  "parameters": [
+                    "\"CloneX\""
+                  ]
+                }
+              ],
+              "actions": [
+                {
+                  "type": {
+                    "value": "SetCameraX"
+                  },
+                  "parameters": [
+                    "",
+                    "=",
+                    "CameraX(GetArgumentAsString(\"SourceLayer\"),GetArgumentAsNumber(\"SourceCamera\"))",
+                    "GetArgumentAsString(\"DestinationLayer\")",
+                    "GetArgumentAsNumber(\"DestinationCamera\")"
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "value": "GetArgumentAsBoolean"
+                  },
+                  "parameters": [
+                    "\"CloneY\""
+                  ]
+                }
+              ],
+              "actions": [
+                {
+                  "type": {
+                    "value": "SetCameraY"
+                  },
+                  "parameters": [
+                    "",
+                    "=",
+                    "CameraY(GetArgumentAsString(\"SourceLayer\"),GetArgumentAsNumber(\"SourceCamera\"))",
+                    "GetArgumentAsString(\"DestinationLayer\")",
+                    "GetArgumentAsNumber(\"DestinationCamera\")"
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "value": "GetArgumentAsBoolean"
+                  },
+                  "parameters": [
+                    "\"CloneZoom\""
+                  ]
+                }
+              ],
+              "actions": [
+                {
+                  "type": {
+                    "value": "ZoomCamera"
+                  },
+                  "parameters": [
+                    "",
+                    "CameraZoom(GetArgumentAsString(\"SourceLayer\"),GetArgumentAsNumber(\"SourceCamera\"))",
+                    "GetArgumentAsString(\"DestinationLayer\")",
+                    "GetArgumentAsNumber(\"DestinationCamera\")"
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "BuiltinCommonInstructions::Standard",
+              "conditions": [
+                {
+                  "type": {
+                    "value": "GetArgumentAsBoolean"
+                  },
+                  "parameters": [
+                    "\"CloneAngle\""
+                  ]
+                }
+              ],
+              "actions": [
+                {
+                  "type": {
+                    "value": "SetCameraAngle"
+                  },
+                  "parameters": [
+                    "",
+                    "=",
+                    "CameraAngle(GetArgumentAsString(\"SourceLayer\"),GetArgumentAsNumber(\"SourceCamera\"))",
+                    "GetArgumentAsString(\"DestinationLayer\")",
+                    "GetArgumentAsNumber(\"DestinationCamera\")"
+                  ]
+                }
+              ]
+            }
+          ],
+          "parameters": [
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Source layer",
+              "longDescription": "",
+              "name": "SourceLayer",
+              "optional": false,
+              "supplementaryInformation": "",
+              "type": "layer"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Source camera",
+              "longDescription": "",
+              "name": "SourceCamera",
+              "optional": false,
+              "supplementaryInformation": "",
+              "type": "expression"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Destination layer",
+              "longDescription": "",
+              "name": "DestinationLayer",
+              "optional": false,
+              "supplementaryInformation": "",
+              "type": "layer"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "",
+              "description": "Destination camera",
+              "longDescription": "",
+              "name": "DestinationCamera",
+              "optional": false,
+              "supplementaryInformation": "",
+              "type": "expression"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "yes",
+              "description": "Clone X position",
+              "longDescription": "",
+              "name": "CloneX",
+              "optional": true,
+              "supplementaryInformation": "",
+              "type": "yesorno"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "yes",
+              "description": "Clone Y position",
+              "longDescription": "",
+              "name": "CloneY",
+              "optional": true,
+              "supplementaryInformation": "",
+              "type": "yesorno"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "yes",
+              "description": "Clone zoom",
+              "longDescription": "",
+              "name": "CloneZoom",
+              "optional": true,
+              "supplementaryInformation": "",
+              "type": "yesorno"
+            },
+            {
+              "codeOnly": false,
+              "defaultValue": "yes",
+              "description": "Clone angle",
+              "longDescription": "",
+              "name": "CloneAngle",
+              "optional": true,
+              "supplementaryInformation": "",
+              "type": "yesorno"
+            }
+          ],
+          "objectGroups": []
+        }
+      ],
+      "eventsBasedBehaviors": []
+    },
+    {
+      "author": "",
+      "category": "",
+      "description": "The camera follows an object according to:\n- a frame rate independent catch-up speed to make the scrolling from smooth to strong\n- a maximum speed to do linear following or slow down the camera when teleporting the object\n- a follow-free zone to avoid scrolling on small movements\n- an offset to see further in one direction\n- an extra delay and catch-up speed to give an impression of speed (useful for dash)\n- position forecasting and delay to simulate a cameraman response time\n\nA platformer dedicated behavior allows to switch of settings when the character is in air or on the floor. This can be used to stabilize the camera when jumping.",
+      "extensionNamespace": "",
+      "fullName": "Smooth Camera",
+      "helpPath": "",
+      "iconUrl": "data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4NCjwhLS0gR2VuZXJhdG9yOiBBZG9iZSBJbGx1c3RyYXRvciAyMy4wLjMsIFNWRyBFeHBvcnQgUGx1Zy1JbiAuIFNWRyBWZXJzaW9uOiA2LjAwIEJ1aWxkIDApICAtLT4NCjxzdmcgdmVyc2lvbj0iMS4xIiBpZD0iSWNvbnMiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIHg9IjBweCIgeT0iMHB4Ig0KCSB2aWV3Qm94PSIwIDAgMzIgMzIiIHN0eWxlPSJlbmFibGUtYmFja2dyb3VuZDpuZXcgMCAwIDMyIDMyOyIgeG1sOnNwYWNlPSJwcmVzZXJ2ZSI+DQo8c3R5bGUgdHlwZT0idGV4dC9jc3MiPg0KCS5zdDB7ZmlsbDpub25lO3N0cm9rZTojMDAwMDAwO3N0cm9rZS13aWR0aDoyO3N0cm9rZS1saW5lY2FwOnJvdW5kO3N0cm9rZS1saW5lam9pbjpyb3VuZDtzdHJva2UtbWl0ZXJsaW1pdDoxMDt9DQoJLnN0MXtmaWxsOm5vbmU7c3Ryb2tlOiMwMDAwMDA7c3Ryb2tlLXdpZHRoOjI7c3Ryb2tlLWxpbmVqb2luOnJvdW5kO3N0cm9rZS1taXRlcmxpbWl0OjEwO30NCjwvc3R5bGU+DQo8cGF0aCBjbGFzcz0ic3QwIiBkPSJNMjQsMTNoLTZjLTEuMSwwLTItMC45LTItMlY1YzAtMS4xLDAuOS0yLDItMmg2YzEuMSwwLDIsMC45LDIsMnY2QzI2LDEyLjEsMjUuMSwxMywyNCwxM3oiLz4NCjxwYXRoIGNsYXNzPSJzdDAiIGQ9Ik0yNiw4djEwYzAsMS4xLTAuOSwyLTIsMkg4Yy0xLjEsMC0yLTAuOS0yLTJWOGMwLTEuMSwwLjktMiwyLTJoOCIvPg0KPGNpcmNsZSBjbGFzcz0ic3QwIiBjeD0iMjEiIGN5PSI4IiByPSIyIi8+DQo8Y2lyY2xlIGNsYXNzPSJzdDAiIGN4PSIxMSIgY3k9IjE2IiByPSIxIi8+DQo8cmVjdCB4PSI5IiB5PSI5IiBjbGFzcz0ic3QwIiB3aWR0aD0iNCIgaGVpZ2h0PSIzIi8+DQo8cG9seWxpbmUgY2xhc3M9InN0MCIgcG9pbnRzPSIyMSwyOSAyMSwyOSAxMSwyOSAxMSwyOSAiLz4NCjxwb2x5bGluZSBjbGFzcz0ic3QwIiBwb2ludHM9IjE4LDIwIDE4LDI5IDE0LDI5IDE0LDIwICIvPg0KPHJlY3QgeD0iNyIgeT0iMyIgY2xhc3M9InN0MCIgd2lkdGg9IjQiIGhlaWdodD0iMyIvPg0KPC9zdmc+DQo=",
+      "name": "SmoothCamera",
+      "previewIconUrl": "https://resources.gdevelop-app.com/assets/Icons/Line Hero Pack/Master/SVG/Computers and Hardware/Computers and Hardware_camcoder_gopro_go_pro_camera.svg",
+      "shortDescription": "Smoothly scroll to follow an object.",
+      "version": "0.1.1",
+      "origin": {
+        "identifier": "SmoothCamera",
+        "name": "gdevelop-extension-store"
+      },
+      "tags": [
+        "camera",
+        "scrolling",
+        "follow",
+        "smooth"
+      ],
+      "authorIds": [
+        "IWykYNRvhCZBN3vEgKEbBPOR3Oc2"
+      ],
+      "dependencies": [],
+      "eventsFunctions": [],
+      "eventsBasedBehaviors": [
+        {
+          "description": "Smoothly scroll to follow an object.",
+          "fullName": "Smooth Camera",
+          "name": "SmoothCamera",
+          "objectType": "",
+          "eventsFunctions": [
+            {
+              "description": "",
+              "fullName": "",
+              "functionType": "Action",
+              "group": "",
+              "name": "onCreated",
+              "private": false,
+              "sentence": "",
+              "events": [
+                {
+                  "type": "BuiltinCommonInstructions::Comment",
+                  "color": {
+                    "b": 109,
+                    "g": 230,
+                    "r": 255,
+                    "textB": 0,
+                    "textG": 0,
+                    "textR": 0
+                  },
+                  "comment": "Update private properties through setters to check their values and initialize state.",
+                  "comment2": ""
+                },
+                {
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [],
+                  "actions": [
+                    {
+                      "type": {
+                        "value": "SmoothCamera::SmoothCamera::SetLeftwardSpeed"
+                      },
+                      "parameters": [
+                        "Object",
+                        "Behavior",
+                        "Object.Behavior::PropertyLeftwardSpeed()",
+                        "log(1 - )"
+                      ]
+                    },
+                    {
+                      "type": {
+                        "value": "SmoothCamera::SmoothCamera::SetRightwardSpeed"
+                      },
+                      "parameters": [
+                        "Object",
+                        "Behavior",
+                        "Object.Behavior::PropertyRightwardSpeed()",
+                        "log(1 - )"
+                      ]
+                    },
+                    {
+                      "type": {
+                        "value": "SmoothCamera::SmoothCamera::SetUpwardSpeed"
+                      },
+                      "parameters": [
+                        "Object",
+                        "Behavior",
+                        "Object.Behavior::PropertyUpwardSpeed()",
+                        "log(1 - )"
+                      ]
+                    },
+                    {
+                      "type": {
+                        "value": "SmoothCamera::SmoothCamera::SetDownwardSpeed"
+                      },
+                      "parameters": [
+                        "Object",
+                        "Behavior",
+                        "Object.Behavior::PropertyDownwardSpeed()",
+                        "log(1 - )"
+                      ]
+                    },
+                    {
+                      "type": {
+                        "value": "SmoothCamera::SmoothCamera::SetLeftwardSpeedMax"
+                      },
+                      "parameters": [
+                        "Object",
+                        "Behavior",
+                        "Object.Behavior::PropertyLeftwardSpeedMax()",
+                        "log(1 - )"
+                      ]
+                    },
+                    {
+                      "type": {
+                        "value": "SmoothCamera::SmoothCamera::SetRightwardSpeedMax"
+                      },
+                      "parameters": [
+                        "Object",
+                        "Behavior",
+                        "Object.Behavior::PropertyRightwardSpeedMax()",
+                        "log(1 - )"
+                      ]
+                    },
+                    {
+                      "type": {
+                        "value": "SmoothCamera::SmoothCamera::SetUpwardSpeedMax"
+                      },
+                      "parameters": [
+                        "Object",
+                        "Behavior",
+                        "Object.Behavior::PropertyUpwardSpeedMax()",
+                        "log(1 - )"
+                      ]
+                    },
+                    {
+                      "type": {
+                        "value": "SmoothCamera::SmoothCamera::SetDownwardSpeedMax"
+                      },
+                      "parameters": [
+                        "Object",
+                        "Behavior",
+                        "Object.Behavior::PropertyDownwardSpeedMax()",
+                        "log(1 - )"
+                      ]
+                    },
+                    {
+                      "type": {
+                        "value": "SmoothCamera::SmoothCamera::SetFollowFreeAreaLeft"
+                      },
+                      "parameters": [
+                        "Object",
+                        "Behavior",
+                        "Object.Behavior::PropertyFollowFreeAreaLeft()",
+                        "log(1 - )"
+                      ]
+                    },
+                    {
+                      "type": {
+                        "value": "SmoothCamera::SmoothCamera::SetFollowFreeAreaRight"
+                      },
+                      "parameters": [
+                        "Object",
+                        "Behavior",
+                        "Object.Behavior::PropertyFollowFreeAreaRight()",
+                        "log(1 - )"
+                      ]
+                    },
+                    {
+                      "type": {
+                        "value": "SmoothCamera::SmoothCamera::SetFollowFreeAreaTop"
+                      },
+                      "parameters": [
+                        "Object",
+                        "Behavior",
+                        "Object.Behavior::PropertyFollowFreeAreaTop()",
+                        "log(1 - )"
+                      ]
+                    },
+                    {
+                      "type": {
+                        "value": "SmoothCamera::SmoothCamera::SetFollowFreeAreaBottom"
+                      },
+                      "parameters": [
+                        "Object",
+                        "Behavior",
+                        "Object.Behavior::PropertyFollowFreeAreaBottom()",
+                        "log(1 - )"
+                      ]
+                    },
+                    {
+                      "type": {
+                        "value": "SmoothCamera::SmoothCamera::SetPropertyCameraDelay"
+                      },
+                      "parameters": [
+                        "Object",
+                        "Behavior",
+                        "=",
+                        "Object.Behavior::PropertyCameraDelay()"
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "parameters": [
+                {
+                  "codeOnly": false,
+                  "defaultValue": "",
+                  "description": "Object",
+                  "longDescription": "",
+                  "name": "Object",
+                  "optional": false,
+                  "supplementaryInformation": "",
+                  "type": "object"
+                },
+                {
+                  "codeOnly": false,
+                  "defaultValue": "",
+                  "description": "Behavior",
+                  "longDescription": "",
+                  "name": "Behavior",
+                  "optional": false,
+                  "supplementaryInformation": "SmoothCamera::SmoothCamera",
+                  "type": "behavior"
+                }
+              ],
+              "objectGroups": []
+            },
+            {
+              "description": "",
+              "fullName": "",
+              "functionType": "Action",
+              "group": "",
+              "name": "doStepPreEvents",
+              "private": false,
+              "sentence": "",
+              "events": [
+                {
+                  "type": "BuiltinCommonInstructions::Comment",
+                  "color": {
+                    "b": 109,
+                    "g": 230,
+                    "r": 255,
+                    "textB": 0,
+                    "textG": 0,
+                    "textR": 0
+                  },
+                  "comment": "Delaying and forecasting can be used at the same time.\nForecasting only use the positions that are older than the one used for delaying.\nThe behavior uses a position history that is split in 2 arrays:\n- one for delaying the position (from TimeFromStart to TimeFromStart - CamearDelay)\n- one for forecasting the position (from TimeFromStart - CamearDelay to TimeFromStart - CamearDelay - ForecastHistoryDuration",
+                  "comment2": ""
+                },
+                {
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [],
+                  "actions": [
+                    {
+                      "type": {
+                        "value": "SmoothCamera::SmoothCamera::UpdateDelayedPosition"
+                      },
+                      "parameters": [
+                        "Object",
+                        "Behavior",
+                        ""
+                      ]
+                    },
+                    {
+                      "type": {
+                        "value": "SmoothCamera::SmoothCamera::UpdateForecastedPosition"
+                      },
+                      "parameters": [
+                        "Object",
+                        "Behavior",
+                        ""
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "BuiltinCommonInstructions::Comment",
+                  "color": {
+                    "b": 109,
+                    "g": 230,
+                    "r": 255,
+                    "textB": 0,
+                    "textG": 0,
+                    "textR": 0
+                  },
+                  "comment": "At each frame, the camera must catchup the target by a given ratio (speed)\ncameraX(t) - targetX = (cameraX(t - 1) - targetX) * speed\n\nThe frame rate must not impact on the catch-up speed, we don't want a speed in ratio per frame but a speed ratio per second, like this:\ncameraX(t) - targetX = (cameraX(t - 1s) - targetX) * speed\n\nOk, but we still need to process each frame, we can use a exponent for this:\ncameraX(t) - targetX = (cameraX(t - timeDelta) - targetX) * speed^timeDelta\ncameraX(t) = targetX + (cameraX(t - timeDelta) - targetX) * exp(timeDelta * ln(speed))\n\npow is probably more efficient than precalculated log if the speed is changed continuously but this might be rare enough.",
+                  "comment2": ""
+                },
+                {
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [
+                    {
+                      "type": {
+                        "value": "SmoothCamera::SmoothCamera::PropertyFollowOnX"
+                      },
+                      "parameters": [
+                        "Object",
+                        "Behavior"
+                      ]
+                    }
+                  ],
+                  "actions": [
+                    {
+                      "type": {
+                        "value": "SmoothCamera::SmoothCamera::SetPropertyOldX"
+                      },
+                      "parameters": [
+                        "Object",
+                        "Behavior",
+                        "=",
+                        "CameraX(Object.Layer(), 0)"
+                      ]
+                    }
+                  ],
+                  "events": [
+                    {
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [
+                        {
+                          "type": {
+                            "value": "CameraX"
+                          },
+                          "parameters": [
+                            "",
+                            ">",
+                            "Object.Behavior::FreeAreaRight()",
+                            "Object.Layer()",
+                            "0"
+                          ]
+                        }
+                      ],
+                      "actions": [
+                        {
+                          "type": {
+                            "value": "SetCameraX"
+                          },
+                          "parameters": [
+                            "",
+                            "=",
+                            "Object.Behavior::FreeAreaRight()\n+ (CameraX(Object.Layer(), 0) - Object.Behavior::FreeAreaRight())\n* exp(TimeDelta() * Object.Behavior::PropertyLogLeftwardSpeed())",
+                            "Object.Layer()",
+                            "0"
+                          ]
+                        }
+                      ],
+                      "events": [
+                        {
+                          "type": "BuiltinCommonInstructions::Standard",
+                          "conditions": [
+                            {
+                              "type": {
+                                "value": "CameraX"
+                              },
+                              "parameters": [
+                                "",
+                                "<",
+                                "Object.Behavior::PropertyOldX() - Object.Behavior::PropertyLeftwardSpeedMax() * TimeDelta()",
+                                "Object.Layer()",
+                                "0"
+                              ]
+                            }
+                          ],
+                          "actions": [
+                            {
+                              "type": {
+                                "value": "SetCameraX"
+                              },
+                              "parameters": [
+                                "",
+                                "=",
+                                "Object.Behavior::PropertyOldX() - Object.Behavior::PropertyLeftwardSpeedMax() * TimeDelta()",
+                                "Object.Layer()",
+                                "0"
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [
+                        {
+                          "type": {
+                            "value": "CameraX"
+                          },
+                          "parameters": [
+                            "",
+                            "<",
+                            "Object.Behavior::FreeAreaLeft()",
+                            "Object.Layer()",
+                            "0"
+                          ]
+                        }
+                      ],
+                      "actions": [
+                        {
+                          "type": {
+                            "value": "SetCameraX"
+                          },
+                          "parameters": [
+                            "",
+                            "=",
+                            "Object.Behavior::FreeAreaLeft()\n+ (CameraX(Object.Layer(), 0) - Object.Behavior::FreeAreaLeft())\n* exp(TimeDelta() * Object.Behavior::PropertyLogRightwardSpeed())",
+                            "Object.Layer()",
+                            "0"
+                          ]
+                        }
+                      ],
+                      "events": [
+                        {
+                          "type": "BuiltinCommonInstructions::Standard",
+                          "conditions": [
+                            {
+                              "type": {
+                                "value": "CameraX"
+                              },
+                              "parameters": [
+                                "",
+                                ">",
+                                "Object.Behavior::PropertyOldX() + Object.Behavior::PropertyRightwardSpeedMax() * TimeDelta()",
+                                "Object.Layer()",
+                                "0"
+                              ]
+                            }
+                          ],
+                          "actions": [
+                            {
+                              "type": {
+                                "value": "SetCameraX"
+                              },
+                              "parameters": [
+                                "",
+                                "=",
+                                "Object.Behavior::PropertyOldX() + Object.Behavior::PropertyRightwardSpeedMax() * TimeDelta()",
+                                "Object.Layer()",
+                                "0"
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [
+                    {
+                      "type": {
+                        "value": "SmoothCamera::SmoothCamera::PropertyFollowOnY"
+                      },
+                      "parameters": [
+                        "Object",
+                        "Behavior"
+                      ]
+                    }
+                  ],
+                  "actions": [
+                    {
+                      "type": {
+                        "value": "SmoothCamera::SmoothCamera::SetPropertyOldY"
+                      },
+                      "parameters": [
+                        "Object",
+                        "Behavior",
+                        "=",
+                        "CameraY(Object.Layer(), 0)"
+                      ]
+                    }
+                  ],
+                  "events": [
+                    {
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [
+                        {
+                          "type": {
+                            "value": "CameraY"
+                          },
+                          "parameters": [
+                            "",
+                            ">",
+                            "Object.Behavior::FreeAreaBottom()",
+                            "Object.Layer()",
+                            "0"
+                          ]
+                        }
+                      ],
+                      "actions": [
+                        {
+                          "type": {
+                            "value": "SetCameraY"
+                          },
+                          "parameters": [
+                            "",
+                            "=",
+                            "Object.Behavior::FreeAreaBottom()\n+ (CameraY(Object.Layer(), 0) - Object.Behavior::FreeAreaBottom())\n* exp(TimeDelta() * Object.Behavior::PropertyLogUpwardSpeed())",
+                            "Object.Layer()",
+                            "0"
+                          ]
+                        }
+                      ],
+                      "events": [
+                        {
+                          "type": "BuiltinCommonInstructions::Standard",
+                          "conditions": [
+                            {
+                              "type": {
+                                "value": "CameraY"
+                              },
+                              "parameters": [
+                                "",
+                                "<",
+                                "Object.Behavior::PropertyOldY() - Object.Behavior::PropertyUpwardSpeedMax() * TimeDelta()",
+                                "Object.Layer()",
+                                "0"
+                              ]
+                            }
+                          ],
+                          "actions": [
+                            {
+                              "type": {
+                                "value": "SetCameraY"
+                              },
+                              "parameters": [
+                                "",
+                                "=",
+                                "Object.Behavior::PropertyOldY() - Object.Behavior::PropertyUpwardSpeedMax() * TimeDelta()",
+                                "Object.Layer()",
+                                "0"
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [
+                        {
+                          "type": {
+                            "value": "CameraY"
+                          },
+                          "parameters": [
+                            "",
+                            "<",
+                            "Object.Behavior::FreeAreaTop()",
+                            "Object.Layer()",
+                            "0"
+                          ]
+                        }
+                      ],
+                      "actions": [
+                        {
+                          "type": {
+                            "value": "SetCameraY"
+                          },
+                          "parameters": [
+                            "",
+                            "=",
+                            "Object.Behavior::FreeAreaTop()\n+ (CameraY(Object.Layer(), 0) - Object.Behavior::FreeAreaTop())\n* exp(TimeDelta() * Object.Behavior::PropertyLogDownwardSpeed())",
+                            "Object.Layer()",
+                            "0"
+                          ]
+                        }
+                      ],
+                      "events": [
+                        {
+                          "type": "BuiltinCommonInstructions::Standard",
+                          "conditions": [
+                            {
+                              "type": {
+                                "value": "CameraY"
+                              },
+                              "parameters": [
+                                "",
+                                ">",
+                                "Object.Behavior::PropertyOldY() + Object.Behavior::PropertyDownwardSpeedMax() * TimeDelta()",
+                                "Object.Layer()",
+                                "0"
+                              ]
+                            }
+                          ],
+                          "actions": [
+                            {
+                              "type": {
+                                "value": "SetCameraY"
+                              },
+                              "parameters": [
+                                "",
+                                "=",
+                                "Object.Behavior::PropertyOldY() + Object.Behavior::PropertyDownwardSpeedMax() * TimeDelta()",
+                                "Object.Layer()",
+                                "0"
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "parameters": [
+                {
+                  "codeOnly": false,
+                  "defaultValue": "",
+                  "description": "Object",
+                  "longDescription": "",
+                  "name": "Object",
+                  "optional": false,
+                  "supplementaryInformation": "",
+                  "type": "object"
+                },
+                {
+                  "codeOnly": false,
+                  "defaultValue": "",
+                  "description": "Behavior",
+                  "longDescription": "",
+                  "name": "Behavior",
+                  "optional": false,
+                  "supplementaryInformation": "SmoothCamera::SmoothCamera",
+                  "type": "behavior"
+                }
+              ],
+              "objectGroups": []
+            },
+            {
+              "description": "Delay the camera according to a maximum speed and catch up the delay.",
+              "fullName": "Wait and catch up",
+              "functionType": "Action",
+              "group": "",
+              "name": "WaitAndCatchUp",
+              "private": false,
+              "sentence": "Delay the camera of _PARAM0_ during: _PARAM2_ seconds according to the maximum speed _PARAM3_;_PARAM4_ seconds and catch up in _PARAM5_ seconds",
+              "events": [
+                {
+                  "type": "BuiltinCommonInstructions::Comment",
+                  "color": {
+                    "b": 109,
+                    "g": 230,
+                    "r": 255,
+                    "textB": 0,
+                    "textG": 0,
+                    "textR": 0
+                  },
+                  "comment": "Maybe the catch-up show be done in constant pixel speed instead of constant time speed.",
+                  "comment2": ""
+                },
+                {
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [],
+                  "actions": [
+                    {
+                      "type": {
+                        "value": "SmoothCamera::SmoothCamera::SetPropertyWaitingEnd"
+                      },
+                      "parameters": [
+                        "Object",
+                        "Behavior",
+                        "=",
+                        "TimeFromStart() + GetArgumentAsNumber(\"WaitingDuration\")"
+                      ]
+                    },
+                    {
+                      "type": {
+                        "value": "SmoothCamera::SmoothCamera::SetPropertyWaitingSpeedXMax"
+                      },
+                      "parameters": [
+                        "Object",
+                        "Behavior",
+                        "=",
+                        "GetArgumentAsNumber(\"WaitingSpeedXMax\")"
+                      ]
+                    },
+                    {
+                      "type": {
+                        "value": "SmoothCamera::SmoothCamera::SetPropertyWaitingSpeedYMax"
+                      },
+                      "parameters": [
+                        "Object",
+                        "Behavior",
+                        "=",
+                        "GetArgumentAsNumber(\"WaitingSpeedYMax\")"
+                      ]
+                    },
+                    {
+                      "type": {
+                        "value": "SmoothCamera::SmoothCamera::SetPropertyCameraDelayCatchUpDuration"
+                      },
+                      "parameters": [
+                        "Object",
+                        "Behavior",
+                        "=",
+                        "GetArgumentAsNumber(\"CatchUpDuration\")"
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "disabled": true,
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [],
+                  "actions": [
+                    {
+                      "type": {
+                        "value": "DebuggerTools::ConsoleLog"
+                      },
+                      "parameters": [
+                        "\"Wait and catch up\"",
+                        "\"info\"",
+                        "\"SmoothCamera\""
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "parameters": [
+                {
+                  "codeOnly": false,
+                  "defaultValue": "",
+                  "description": "Object",
+                  "longDescription": "",
+                  "name": "Object",
+                  "optional": false,
+                  "supplementaryInformation": "",
+                  "type": "object"
+                },
+                {
+                  "codeOnly": false,
+                  "defaultValue": "",
+                  "description": "Behavior",
+                  "longDescription": "",
+                  "name": "Behavior",
+                  "optional": false,
+                  "supplementaryInformation": "SmoothCamera::SmoothCamera",
+                  "type": "behavior"
+                },
+                {
+                  "codeOnly": false,
+                  "defaultValue": "",
+                  "description": "Waiting duration (in seconds)",
+                  "longDescription": "",
+                  "name": "WaitingDuration",
+                  "optional": false,
+                  "supplementaryInformation": "",
+                  "type": "expression"
+                },
+                {
+                  "codeOnly": false,
+                  "defaultValue": "",
+                  "description": "Waiting maximum camera target speed X",
+                  "longDescription": "",
+                  "name": "WaitingSpeedXMax",
+                  "optional": false,
+                  "supplementaryInformation": "",
+                  "type": "expression"
+                },
+                {
+                  "codeOnly": false,
+                  "defaultValue": "",
+                  "description": "Waiting maximum camera target speed Y",
+                  "longDescription": "",
+                  "name": "WaitingSpeedYMax",
+                  "optional": false,
+                  "supplementaryInformation": "",
+                  "type": "expression"
+                },
+                {
+                  "codeOnly": false,
+                  "defaultValue": "",
+                  "description": "Catch up duration (in seconds)",
+                  "longDescription": "",
+                  "name": "CatchUpDuration",
+                  "optional": false,
+                  "supplementaryInformation": "",
+                  "type": "expression"
+                }
+              ],
+              "objectGroups": []
+            },
+            {
+              "description": "Draw the targeted and actual camera position.",
+              "fullName": "Draw debug",
+              "functionType": "Action",
+              "group": "",
+              "name": "DrawDebug",
+              "private": false,
+              "sentence": "Draw targeted and actual camera position for _PARAM0_ on _PARAM2_",
+              "events": [
+                {
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [],
+                  "actions": [
+                    {
+                      "type": {
+                        "value": "PrimitiveDrawing::FillOpacity"
+                      },
+                      "parameters": [
+                        "ShapePainter",
+                        "=",
+                        "0"
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "colorB": 228,
+                  "colorG": 176,
+                  "colorR": 74,
+                  "creationTime": 0,
+                  "name": "Path used by the forecasting",
+                  "source": "",
+                  "type": "BuiltinCommonInstructions::Group",
+                  "events": [
+                    {
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [
+                        {
+                          "type": {
+                            "value": "Egal"
+                          },
+                          "parameters": [
+                            "Object.VariableChildCount(__SmoothCamera_ForecastHistoryTime)",
+                            ">",
+                            "0"
+                          ]
+                        }
+                      ],
+                      "actions": [
+                        {
+                          "type": {
+                            "value": "SmoothCamera::SmoothCamera::SetPropertyIndex"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Behavior",
+                            "=",
+                            "0"
+                          ]
+                        },
+                        {
+                          "type": {
+                            "value": "PrimitiveDrawing::OutlineColor"
+                          },
+                          "parameters": [
+                            "ShapePainter",
+                            "\"245;166;35\""
+                          ]
+                        },
+                        {
+                          "type": {
+                            "value": "PrimitiveDrawing::BeginFillPath"
+                          },
+                          "parameters": [
+                            "ShapePainter",
+                            "Object.Variable(__SmoothCamera_ForecastHistoryX[0])",
+                            "Object.Variable(__SmoothCamera_ForecastHistoryY[0])"
+                          ]
+                        }
+                      ],
+                      "events": [
+                        {
+                          "type": "BuiltinCommonInstructions::Repeat",
+                          "repeatExpression": "Object.VariableChildCount(__SmoothCamera_ForecastHistoryX)",
+                          "conditions": [],
+                          "actions": [
+                            {
+                              "type": {
+                                "value": "PrimitiveDrawing::PathLineTo"
+                              },
+                              "parameters": [
+                                "ShapePainter",
+                                "Object.Variable(__SmoothCamera_ForecastHistoryX[Object.Behavior::PropertyIndex()])",
+                                "Object.Variable(__SmoothCamera_ForecastHistoryY[Object.Behavior::PropertyIndex()])"
+                              ]
+                            },
+                            {
+                              "type": {
+                                "value": "SmoothCamera::SmoothCamera::SetPropertyIndex"
+                              },
+                              "parameters": [
+                                "Object",
+                                "Behavior",
+                                "+",
+                                "1"
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "BuiltinCommonInstructions::Standard",
+                          "conditions": [],
+                          "actions": [
+                            {
+                              "type": {
+                                "value": "PrimitiveDrawing::EndFillPath"
+                              },
+                              "parameters": [
+                                "ShapePainter"
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ],
+                  "parameters": []
+                },
+                {
+                  "colorB": 228,
+                  "colorG": 176,
+                  "colorR": 74,
+                  "creationTime": 0,
+                  "name": "Follow-free area.",
+                  "source": "",
+                  "type": "BuiltinCommonInstructions::Group",
+                  "events": [
+                    {
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [
+                        {
+                          "type": {
+                            "value": "BuiltinCommonInstructions::Or"
+                          },
+                          "parameters": [],
+                          "subInstructions": [
+                            {
+                              "type": {
+                                "value": "SmoothCamera::SmoothCamera::PropertyFollowFreeAreaLeft"
+                              },
+                              "parameters": [
+                                "Object",
+                                "Behavior",
+                                "!=",
+                                "0"
+                              ]
+                            },
+                            {
+                              "type": {
+                                "value": "SmoothCamera::SmoothCamera::PropertyFollowFreeAreaRight"
+                              },
+                              "parameters": [
+                                "Object",
+                                "Behavior",
+                                "!=",
+                                "0"
+                              ]
+                            },
+                            {
+                              "type": {
+                                "value": "SmoothCamera::SmoothCamera::PropertyFollowFreeAreaTop"
+                              },
+                              "parameters": [
+                                "Object",
+                                "Behavior",
+                                "!=",
+                                "0"
+                              ]
+                            },
+                            {
+                              "type": {
+                                "value": "SmoothCamera::SmoothCamera::PropertyFollowFreeAreaBottom"
+                              },
+                              "parameters": [
+                                "Object",
+                                "Behavior",
+                                "!=",
+                                "0"
+                              ]
+                            }
+                          ]
+                        }
+                      ],
+                      "actions": [
+                        {
+                          "type": {
+                            "value": "PrimitiveDrawing::OutlineColor"
+                          },
+                          "parameters": [
+                            "ShapePainter",
+                            "\"126;211;33\""
+                          ]
+                        },
+                        {
+                          "type": {
+                            "value": "PrimitiveDrawing::Rectangle"
+                          },
+                          "parameters": [
+                            "ShapePainter",
+                            "Object.Behavior::FreeAreaLeft() - 1",
+                            "Object.Behavior::FreeAreaTop() - 1",
+                            "Object.Behavior::FreeAreaRight() + 1",
+                            "Object.Behavior::FreeAreaBottom() + 1"
+                          ]
+                        }
+                      ]
+                    }
+                  ],
+                  "parameters": []
+                },
+                {
+                  "colorB": 228,
+                  "colorG": 176,
+                  "colorR": 74,
+                  "creationTime": 0,
+                  "name": "Linear regression vector used by the forcasting.",
+                  "source": "",
+                  "type": "BuiltinCommonInstructions::Group",
+                  "events": [
+                    {
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [],
+                      "actions": [
+                        {
+                          "type": {
+                            "value": "PrimitiveDrawing::OutlineColor"
+                          },
+                          "parameters": [
+                            "ShapePainter",
+                            "\"208;2;27\""
+                          ]
+                        },
+                        {
+                          "type": {
+                            "value": "PrimitiveDrawing::LineV2"
+                          },
+                          "parameters": [
+                            "ShapePainter",
+                            "Object.Behavior::PropertyProjectedOldestX()",
+                            "Object.Behavior::PropertyProjectedOldestY()",
+                            "Object.Behavior::PropertyProjectedNewestX()",
+                            "Object.Behavior::PropertyProjectedNewestY()",
+                            "1"
+                          ]
+                        }
+                      ]
+                    }
+                  ],
+                  "parameters": []
+                },
+                {
+                  "colorB": 228,
+                  "colorG": 176,
+                  "colorR": 74,
+                  "creationTime": 0,
+                  "name": "Targeted and actual camera position",
+                  "source": "",
+                  "type": "BuiltinCommonInstructions::Group",
+                  "events": [
+                    {
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [],
+                      "actions": [
+                        {
+                          "type": {
+                            "value": "PrimitiveDrawing::Circle"
+                          },
+                          "parameters": [
+                            "ShapePainter",
+                            "Object.Behavior::PropertyForecastedX()",
+                            "Object.Behavior::PropertyForecastedY()",
+                            "3"
+                          ]
+                        },
+                        {
+                          "type": {
+                            "value": "PrimitiveDrawing::LineV2"
+                          },
+                          "parameters": [
+                            "ShapePainter",
+                            "CameraX(Object.Layer(), 0)",
+                            "CameraY(Object.Layer(), 0) - 4",
+                            "CameraX(Object.Layer(), 0)",
+                            "CameraY(Object.Layer(), 0) + 4",
+                            "1"
+                          ]
+                        },
+                        {
+                          "type": {
+                            "value": "PrimitiveDrawing::LineV2"
+                          },
+                          "parameters": [
+                            "ShapePainter",
+                            "CameraX(Object.Layer(), 0) - 4",
+                            "CameraY(Object.Layer(), 0)",
+                            "CameraX(Object.Layer(), 0) + 4",
+                            "CameraY(Object.Layer(), 0)",
+                            "1"
+                          ]
+                        }
+                      ]
+                    }
+                  ],
+                  "parameters": []
+                }
+              ],
+              "parameters": [
+                {
+                  "codeOnly": false,
+                  "defaultValue": "",
+                  "description": "Object",
+                  "longDescription": "",
+                  "name": "Object",
+                  "optional": false,
+                  "supplementaryInformation": "",
+                  "type": "object"
+                },
+                {
+                  "codeOnly": false,
+                  "defaultValue": "",
+                  "description": "Behavior",
+                  "longDescription": "",
+                  "name": "Behavior",
+                  "optional": false,
+                  "supplementaryInformation": "SmoothCamera::SmoothCamera",
+                  "type": "behavior"
+                },
+                {
+                  "codeOnly": false,
+                  "defaultValue": "",
+                  "description": "Shape painter",
+                  "longDescription": "",
+                  "name": "ShapePainter",
+                  "optional": false,
+                  "supplementaryInformation": "PrimitiveDrawing::Drawer",
+                  "type": "objectList"
+                }
+              ],
+              "objectGroups": []
+            },
+            {
+              "description": "Enable or disable the following on X axis.",
+              "fullName": "Follow on X",
+              "functionType": "Action",
+              "group": "Camera configuration",
+              "name": "SetFollowOnX",
+              "private": false,
+              "sentence": "The camera follows _PARAM0_ on X axis: _PARAM2_",
+              "events": [
+                {
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [],
+                  "actions": [
+                    {
+                      "type": {
+                        "value": "SmoothCamera::SmoothCamera::SetPropertyFollowOnX"
+                      },
+                      "parameters": [
+                        "Object",
+                        "Behavior",
+                        ""
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [
+                    {
+                      "type": {
+                        "value": "GetArgumentAsBoolean"
+                      },
+                      "parameters": [
+                        "\"FollowOnX\""
+                      ]
+                    }
+                  ],
+                  "actions": [
+                    {
+                      "type": {
+                        "value": "SmoothCamera::SmoothCamera::SetPropertyFollowOnX"
+                      },
+                      "parameters": [
+                        "Object",
+                        "Behavior",
+                        "yes"
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "parameters": [
+                {
+                  "codeOnly": false,
+                  "defaultValue": "",
+                  "description": "Object",
+                  "longDescription": "",
+                  "name": "Object",
+                  "optional": false,
+                  "supplementaryInformation": "",
+                  "type": "object"
+                },
+                {
+                  "codeOnly": false,
+                  "defaultValue": "",
+                  "description": "Behavior",
+                  "longDescription": "",
+                  "name": "Behavior",
+                  "optional": false,
+                  "supplementaryInformation": "SmoothCamera::SmoothCamera",
+                  "type": "behavior"
+                },
+                {
+                  "codeOnly": false,
+                  "defaultValue": "",
+                  "description": "Follow on X axis",
+                  "longDescription": "",
+                  "name": "FollowOnX",
+                  "optional": false,
+                  "supplementaryInformation": "",
+                  "type": "yesorno"
+                }
+              ],
+              "objectGroups": []
+            },
+            {
+              "description": "Enable or disable the following on Y axis.",
+              "fullName": "Follow on Y",
+              "functionType": "Action",
+              "group": "Camera configuration",
+              "name": "SetFollowOnY",
+              "private": false,
+              "sentence": "The camera follows _PARAM0_ on Y axis: _PARAM2_",
+              "events": [
+                {
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [],
+                  "actions": [
+                    {
+                      "type": {
+                        "value": "SmoothCamera::SmoothCamera::SetPropertyFollowOnY"
+                      },
+                      "parameters": [
+                        "Object",
+                        "Behavior",
+                        ""
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [
+                    {
+                      "type": {
+                        "value": "GetArgumentAsBoolean"
+                      },
+                      "parameters": [
+                        "\"FollowOnY\""
+                      ]
+                    }
+                  ],
+                  "actions": [
+                    {
+                      "type": {
+                        "value": "SmoothCamera::SmoothCamera::SetPropertyFollowOnY"
+                      },
+                      "parameters": [
+                        "Object",
+                        "Behavior",
+                        "yes"
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "parameters": [
+                {
+                  "codeOnly": false,
+                  "defaultValue": "",
+                  "description": "Object",
+                  "longDescription": "",
+                  "name": "Object",
+                  "optional": false,
+                  "supplementaryInformation": "",
+                  "type": "object"
+                },
+                {
+                  "codeOnly": false,
+                  "defaultValue": "",
+                  "description": "Behavior",
+                  "longDescription": "",
+                  "name": "Behavior",
+                  "optional": false,
+                  "supplementaryInformation": "SmoothCamera::SmoothCamera",
+                  "type": "behavior"
+                },
+                {
+                  "codeOnly": false,
+                  "defaultValue": "",
+                  "description": "Follow on Y axis",
+                  "longDescription": "",
+                  "name": "FollowOnY",
+                  "optional": false,
+                  "supplementaryInformation": "",
+                  "type": "yesorno"
+                }
+              ],
+              "objectGroups": []
+            },
+            {
+              "description": "Change the camera follow free area right border.",
+              "fullName": "Follow free area right border",
+              "functionType": "Action",
+              "group": "Camera configuration",
+              "name": "SetFollowFreeAreaRight",
+              "private": false,
+              "sentence": "Change the camera follow free area right border of _PARAM0_: _PARAM2_",
+              "events": [
+                {
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [],
+                  "actions": [
+                    {
+                      "type": {
+                        "value": "SmoothCamera::SmoothCamera::SetPropertyFollowFreeAreaTop"
+                      },
+                      "parameters": [
+                        "Object",
+                        "Behavior",
+                        "=",
+                        "max(0, GetArgumentAsNumber(\"SetFollowFreeAreaRight\"))"
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "parameters": [
+                {
+                  "codeOnly": false,
+                  "defaultValue": "",
+                  "description": "Object",
+                  "longDescription": "",
+                  "name": "Object",
+                  "optional": false,
+                  "supplementaryInformation": "",
+                  "type": "object"
+                },
+                {
+                  "codeOnly": false,
+                  "defaultValue": "",
+                  "description": "Behavior",
+                  "longDescription": "",
+                  "name": "Behavior",
+                  "optional": false,
+                  "supplementaryInformation": "SmoothCamera::SmoothCamera",
+                  "type": "behavior"
+                },
+                {
+                  "codeOnly": false,
+                  "defaultValue": "",
+                  "description": "Follow free area right border",
+                  "longDescription": "",
+                  "name": "SetFollowFreeAreaRight",
+                  "optional": false,
+                  "supplementaryInformation": "",
+                  "type": "expression"
+                }
+              ],
+              "objectGroups": []
+            },
+            {
+              "description": "Change the camera follow free area left border.",
+              "fullName": "Follow free area left border",
+              "functionType": "Action",
+              "group": "Camera configuration",
+              "name": "SetFollowFreeAreaLeft",
+              "private": false,
+              "sentence": "Change the camera follow free area left border of _PARAM0_: _PARAM2_",
+              "events": [
+                {
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [],
+                  "actions": [
+                    {
+                      "type": {
+                        "value": "SmoothCamera::SmoothCamera::SetPropertyFollowFreeAreaTop"
+                      },
+                      "parameters": [
+                        "Object",
+                        "Behavior",
+                        "=",
+                        "max(0, GetArgumentAsNumber(\"SetFollowFreeAreaLeft\"))"
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "parameters": [
+                {
+                  "codeOnly": false,
+                  "defaultValue": "",
+                  "description": "Object",
+                  "longDescription": "",
+                  "name": "Object",
+                  "optional": false,
+                  "supplementaryInformation": "",
+                  "type": "object"
+                },
+                {
+                  "codeOnly": false,
+                  "defaultValue": "",
+                  "description": "Behavior",
+                  "longDescription": "",
+                  "name": "Behavior",
+                  "optional": false,
+                  "supplementaryInformation": "SmoothCamera::SmoothCamera",
+                  "type": "behavior"
+                },
+                {
+                  "codeOnly": false,
+                  "defaultValue": "",
+                  "description": "Follow free area left border",
+                  "longDescription": "",
+                  "name": "SetFollowFreeAreaLeft",
+                  "optional": false,
+                  "supplementaryInformation": "",
+                  "type": "expression"
+                }
+              ],
+              "objectGroups": []
+            },
+            {
+              "description": "Change the camera follow free area top border.",
+              "fullName": "Follow free area top border",
+              "functionType": "Action",
+              "group": "Camera configuration",
+              "name": "SetFollowFreeAreaTop",
+              "private": false,
+              "sentence": "Change the camera follow free area top border of _PARAM0_: _PARAM2_",
+              "events": [
+                {
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [],
+                  "actions": [
+                    {
+                      "type": {
+                        "value": "SmoothCamera::SmoothCamera::SetPropertyFollowFreeAreaTop"
+                      },
+                      "parameters": [
+                        "Object",
+                        "Behavior",
+                        "=",
+                        "max(0, GetArgumentAsNumber(\"FollowFreeAreaTop\"))"
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "parameters": [
+                {
+                  "codeOnly": false,
+                  "defaultValue": "",
+                  "description": "Object",
+                  "longDescription": "",
+                  "name": "Object",
+                  "optional": false,
+                  "supplementaryInformation": "",
+                  "type": "object"
+                },
+                {
+                  "codeOnly": false,
+                  "defaultValue": "",
+                  "description": "Behavior",
+                  "longDescription": "",
+                  "name": "Behavior",
+                  "optional": false,
+                  "supplementaryInformation": "SmoothCamera::SmoothCamera",
+                  "type": "behavior"
+                },
+                {
+                  "codeOnly": false,
+                  "defaultValue": "",
+                  "description": "Follow free area top border",
+                  "longDescription": "",
+                  "name": "FollowFreeAreaTop",
+                  "optional": false,
+                  "supplementaryInformation": "",
+                  "type": "expression"
+                }
+              ],
+              "objectGroups": []
+            },
+            {
+              "description": "Change the camera follow free area bottom border.",
+              "fullName": "Follow free area bottom border",
+              "functionType": "Action",
+              "group": "Camera configuration",
+              "name": "SetFollowFreeAreaBottom",
+              "private": false,
+              "sentence": "Change the camera follow free area bottom border of _PARAM0_: _PARAM2_",
+              "events": [
+                {
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [],
+                  "actions": [
+                    {
+                      "type": {
+                        "value": "SmoothCamera::SmoothCamera::SetPropertyFollowFreeAreaBottom"
+                      },
+                      "parameters": [
+                        "Object",
+                        "Behavior",
+                        "=",
+                        "max(0, GetArgumentAsNumber(\"SetFollowFreeAreaBottom\"))"
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "parameters": [
+                {
+                  "codeOnly": false,
+                  "defaultValue": "",
+                  "description": "Object",
+                  "longDescription": "",
+                  "name": "Object",
+                  "optional": false,
+                  "supplementaryInformation": "",
+                  "type": "object"
+                },
+                {
+                  "codeOnly": false,
+                  "defaultValue": "",
+                  "description": "Behavior",
+                  "longDescription": "",
+                  "name": "Behavior",
+                  "optional": false,
+                  "supplementaryInformation": "SmoothCamera::SmoothCamera",
+                  "type": "behavior"
+                },
+                {
+                  "codeOnly": false,
+                  "defaultValue": "",
+                  "description": "Follow free area bottom border",
+                  "longDescription": "",
+                  "name": "SetFollowFreeAreaBottom",
+                  "optional": false,
+                  "supplementaryInformation": "",
+                  "type": "expression"
+                }
+              ],
+              "objectGroups": []
+            },
+            {
+              "description": "Change the camera leftward maximum speed (in pixels per second).",
+              "fullName": "Leftward maximum speed",
+              "functionType": "Action",
+              "group": "Camera configuration",
+              "name": "SetLeftwardSpeedMax",
+              "private": false,
+              "sentence": "Change the camera leftward maximum speed of _PARAM0_: _PARAM2_",
+              "events": [
+                {
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [],
+                  "actions": [
+                    {
+                      "type": {
+                        "value": "SmoothCamera::SmoothCamera::SetPropertyLeftwardSpeedMax"
+                      },
+                      "parameters": [
+                        "Object",
+                        "Behavior",
+                        "=",
+                        "max(0, GetArgumentAsNumber(\"Speed\"))"
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "parameters": [
+                {
+                  "codeOnly": false,
+                  "defaultValue": "",
+                  "description": "Object",
+                  "longDescription": "",
+                  "name": "Object",
+                  "optional": false,
+                  "supplementaryInformation": "",
+                  "type": "object"
+                },
+                {
+                  "codeOnly": false,
+                  "defaultValue": "",
+                  "description": "Behavior",
+                  "longDescription": "",
+                  "name": "Behavior",
+                  "optional": false,
+                  "supplementaryInformation": "SmoothCamera::SmoothCamera",
+                  "type": "behavior"
+                },
+                {
+                  "codeOnly": false,
+                  "defaultValue": "",
+                  "description": "Leftward maximum speed (in ratio per second)",
+                  "longDescription": "",
+                  "name": "Speed",
+                  "optional": false,
+                  "supplementaryInformation": "",
+                  "type": "expression"
+                }
+              ],
+              "objectGroups": []
+            },
+            {
+              "description": "Change the camera rightward maximum speed (in pixels per second).",
+              "fullName": "Rightward maximum speed",
+              "functionType": "Action",
+              "group": "Camera configuration",
+              "name": "SetRightwardSpeedMax",
+              "private": false,
+              "sentence": "Change the camera rightward maximum speed of _PARAM0_: _PARAM2_",
+              "events": [
+                {
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [],
+                  "actions": [
+                    {
+                      "type": {
+                        "value": "SmoothCamera::SmoothCamera::SetPropertyLeftwardSpeedMax"
+                      },
+                      "parameters": [
+                        "Object",
+                        "Behavior",
+                        "=",
+                        "max(0, GetArgumentAsNumber(\"Speed\"))"
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "parameters": [
+                {
+                  "codeOnly": false,
+                  "defaultValue": "",
+                  "description": "Object",
+                  "longDescription": "",
+                  "name": "Object",
+                  "optional": false,
+                  "supplementaryInformation": "",
+                  "type": "object"
+                },
+                {
+                  "codeOnly": false,
+                  "defaultValue": "",
+                  "description": "Behavior",
+                  "longDescription": "",
+                  "name": "Behavior",
+                  "optional": false,
+                  "supplementaryInformation": "SmoothCamera::SmoothCamera",
+                  "type": "behavior"
+                },
+                {
+                  "codeOnly": false,
+                  "defaultValue": "",
+                  "description": "Rightward maximum speed (in pixels per second)",
+                  "longDescription": "",
+                  "name": "Speed",
+                  "optional": false,
+                  "supplementaryInformation": "",
+                  "type": "expression"
+                }
+              ],
+              "objectGroups": []
+            },
+            {
+              "description": "Change the camera upward maximum speed (in pixels per second).",
+              "fullName": "Upward maximum speed",
+              "functionType": "Action",
+              "group": "Camera configuration",
+              "name": "SetUpwardSpeedMax",
+              "private": false,
+              "sentence": "Change the camera upward maximum speed of _PARAM0_: _PARAM2_",
+              "events": [
+                {
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [],
+                  "actions": [
+                    {
+                      "type": {
+                        "value": "SmoothCamera::SmoothCamera::SetPropertyUpwardSpeedMax"
+                      },
+                      "parameters": [
+                        "Object",
+                        "Behavior",
+                        "=",
+                        "max(0, GetArgumentAsNumber(\"Speed\"))"
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "parameters": [
+                {
+                  "codeOnly": false,
+                  "defaultValue": "",
+                  "description": "Object",
+                  "longDescription": "",
+                  "name": "Object",
+                  "optional": false,
+                  "supplementaryInformation": "",
+                  "type": "object"
+                },
+                {
+                  "codeOnly": false,
+                  "defaultValue": "",
+                  "description": "Behavior",
+                  "longDescription": "",
+                  "name": "Behavior",
+                  "optional": false,
+                  "supplementaryInformation": "SmoothCamera::SmoothCamera",
+                  "type": "behavior"
+                },
+                {
+                  "codeOnly": false,
+                  "defaultValue": "",
+                  "description": "Upward maximum speed (in pixels per second)",
+                  "longDescription": "",
+                  "name": "Speed",
+                  "optional": false,
+                  "supplementaryInformation": "",
+                  "type": "expression"
+                }
+              ],
+              "objectGroups": []
+            },
+            {
+              "description": "Change the camera downward maximum speed (in pixels per second).",
+              "fullName": "Downward maximum speed",
+              "functionType": "Action",
+              "group": "Camera configuration",
+              "name": "SetDownwardSpeedMax",
+              "private": false,
+              "sentence": "Change the camera downward maximum speed of _PARAM0_: _PARAM2_",
+              "events": [
+                {
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [],
+                  "actions": [
+                    {
+                      "type": {
+                        "value": "SmoothCamera::SmoothCamera::SetPropertyDownwardSpeedMax"
+                      },
+                      "parameters": [
+                        "Object",
+                        "Behavior",
+                        "=",
+                        "max(0, GetArgumentAsNumber(\"Speed\"))"
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "parameters": [
+                {
+                  "codeOnly": false,
+                  "defaultValue": "",
+                  "description": "Object",
+                  "longDescription": "",
+                  "name": "Object",
+                  "optional": false,
+                  "supplementaryInformation": "",
+                  "type": "object"
+                },
+                {
+                  "codeOnly": false,
+                  "defaultValue": "",
+                  "description": "Behavior",
+                  "longDescription": "",
+                  "name": "Behavior",
+                  "optional": false,
+                  "supplementaryInformation": "SmoothCamera::SmoothCamera",
+                  "type": "behavior"
+                },
+                {
+                  "codeOnly": false,
+                  "defaultValue": "",
+                  "description": "Downward maximum speed (in pixels per second)",
+                  "longDescription": "",
+                  "name": "Speed",
+                  "optional": false,
+                  "supplementaryInformation": "",
+                  "type": "expression"
+                }
+              ],
+              "objectGroups": []
+            },
+            {
+              "description": "Change the camera leftward catch-up speed (in ratio per second).",
+              "fullName": "Leftward catch-up speed",
+              "functionType": "Action",
+              "group": "Camera configuration",
+              "name": "SetLeftwardSpeed",
+              "private": false,
+              "sentence": "Change the camera leftward catch-up speed of _PARAM0_: _PARAM2_",
+              "events": [
+                {
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [],
+                  "actions": [
+                    {
+                      "type": {
+                        "value": "SmoothCamera::SmoothCamera::SetPropertyLeftwardSpeed"
+                      },
+                      "parameters": [
+                        "Object",
+                        "Behavior",
+                        "=",
+                        "clamp(0, 1, GetArgumentAsNumber(\"LeftwardSpeed\"))"
+                      ]
+                    },
+                    {
+                      "type": {
+                        "value": "SmoothCamera::SmoothCamera::SetPropertyLogLeftwardSpeed"
+                      },
+                      "parameters": [
+                        "Object",
+                        "Behavior",
+                        "=",
+                        "log(1 - Object.Behavior::PropertyLeftwardSpeed())"
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "parameters": [
+                {
+                  "codeOnly": false,
+                  "defaultValue": "",
+                  "description": "Object",
+                  "longDescription": "",
+                  "name": "Object",
+                  "optional": false,
+                  "supplementaryInformation": "",
+                  "type": "object"
+                },
+                {
+                  "codeOnly": false,
+                  "defaultValue": "",
+                  "description": "Behavior",
+                  "longDescription": "",
+                  "name": "Behavior",
+                  "optional": false,
+                  "supplementaryInformation": "SmoothCamera::SmoothCamera",
+                  "type": "behavior"
+                },
+                {
+                  "codeOnly": false,
+                  "defaultValue": "",
+                  "description": "Leftward catch-up speed (in ratio per second)",
+                  "longDescription": "",
+                  "name": "LeftwardSpeed",
+                  "optional": false,
+                  "supplementaryInformation": "",
+                  "type": "expression"
+                }
+              ],
+              "objectGroups": []
+            },
+            {
+              "description": "Change the camera rightward catch-up speed (in ratio per second).",
+              "fullName": "Rightward catch-up speed",
+              "functionType": "Action",
+              "group": "Camera configuration",
+              "name": "SetRightwardSpeed",
+              "private": false,
+              "sentence": "Change the camera rightward catch-up speed of _PARAM0_: _PARAM2_",
+              "events": [
+                {
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [],
+                  "actions": [
+                    {
+                      "type": {
+                        "value": "SmoothCamera::SmoothCamera::SetPropertyRightwardSpeed"
+                      },
+                      "parameters": [
+                        "Object",
+                        "Behavior",
+                        "=",
+                        "clamp(0, 1, GetArgumentAsNumber(\"RightwardSpeed\"))"
+                      ]
+                    },
+                    {
+                      "type": {
+                        "value": "SmoothCamera::SmoothCamera::SetPropertyLogRightwardSpeed"
+                      },
+                      "parameters": [
+                        "Object",
+                        "Behavior",
+                        "=",
+                        "log(1 - Object.Behavior::PropertyRightwardSpeed())"
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "parameters": [
+                {
+                  "codeOnly": false,
+                  "defaultValue": "",
+                  "description": "Object",
+                  "longDescription": "",
+                  "name": "Object",
+                  "optional": false,
+                  "supplementaryInformation": "",
+                  "type": "object"
+                },
+                {
+                  "codeOnly": false,
+                  "defaultValue": "",
+                  "description": "Behavior",
+                  "longDescription": "",
+                  "name": "Behavior",
+                  "optional": false,
+                  "supplementaryInformation": "SmoothCamera::SmoothCamera",
+                  "type": "behavior"
+                },
+                {
+                  "codeOnly": false,
+                  "defaultValue": "",
+                  "description": "Rightward catch-up speed (in ratio per second)",
+                  "longDescription": "",
+                  "name": "RightwardSpeed",
+                  "optional": false,
+                  "supplementaryInformation": "",
+                  "type": "expression"
+                }
+              ],
+              "objectGroups": []
+            },
+            {
+              "description": "Change the camera downward catch-up speed (in ratio per second).",
+              "fullName": "Downward catch-up speed",
+              "functionType": "Action",
+              "group": "Camera configuration",
+              "name": "SetDownwardSpeed",
+              "private": false,
+              "sentence": "Change the camera downward catch-up speed of _PARAM0_: _PARAM2_",
+              "events": [
+                {
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [],
+                  "actions": [
+                    {
+                      "type": {
+                        "value": "SmoothCamera::SmoothCamera::SetPropertyDownwardSpeed"
+                      },
+                      "parameters": [
+                        "Object",
+                        "Behavior",
+                        "=",
+                        "clamp(0, 1, GetArgumentAsNumber(\"DownwardSpeed\"))"
+                      ]
+                    },
+                    {
+                      "type": {
+                        "value": "SmoothCamera::SmoothCamera::SetPropertyLogDownwardSpeed"
+                      },
+                      "parameters": [
+                        "Object",
+                        "Behavior",
+                        "=",
+                        "log(1 - Object.Behavior::PropertyDownwardSpeed())"
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "parameters": [
+                {
+                  "codeOnly": false,
+                  "defaultValue": "",
+                  "description": "Object",
+                  "longDescription": "",
+                  "name": "Object",
+                  "optional": false,
+                  "supplementaryInformation": "",
+                  "type": "object"
+                },
+                {
+                  "codeOnly": false,
+                  "defaultValue": "",
+                  "description": "Behavior",
+                  "longDescription": "",
+                  "name": "Behavior",
+                  "optional": false,
+                  "supplementaryInformation": "SmoothCamera::SmoothCamera",
+                  "type": "behavior"
+                },
+                {
+                  "codeOnly": false,
+                  "defaultValue": "",
+                  "description": "Downward catch-up speed (in ratio per second)",
+                  "longDescription": "",
+                  "name": "DownwardSpeed",
+                  "optional": false,
+                  "supplementaryInformation": "",
+                  "type": "expression"
+                }
+              ],
+              "objectGroups": []
+            },
+            {
+              "description": "Change the camera upward catch-up speed (in ratio per second).",
+              "fullName": "Upward catch-up speed",
+              "functionType": "Action",
+              "group": "Camera configuration",
+              "name": "SetUpwardSpeed",
+              "private": false,
+              "sentence": "Change the camera upward catch-up speed of _PARAM0_: _PARAM2_",
+              "events": [
+                {
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [],
+                  "actions": [
+                    {
+                      "type": {
+                        "value": "SmoothCamera::SmoothCamera::SetPropertyUpwardSpeed"
+                      },
+                      "parameters": [
+                        "Object",
+                        "Behavior",
+                        "=",
+                        "clamp(0, 1, GetArgumentAsNumber(\"UpwardSpeed\"))"
+                      ]
+                    },
+                    {
+                      "type": {
+                        "value": "SmoothCamera::SmoothCamera::SetPropertyLogUpwardSpeed"
+                      },
+                      "parameters": [
+                        "Object",
+                        "Behavior",
+                        "=",
+                        "log(1 - Object.Behavior::PropertyUpwardSpeed())"
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "parameters": [
+                {
+                  "codeOnly": false,
+                  "defaultValue": "",
+                  "description": "Object",
+                  "longDescription": "",
+                  "name": "Object",
+                  "optional": false,
+                  "supplementaryInformation": "",
+                  "type": "object"
+                },
+                {
+                  "codeOnly": false,
+                  "defaultValue": "",
+                  "description": "Behavior",
+                  "longDescription": "",
+                  "name": "Behavior",
+                  "optional": false,
+                  "supplementaryInformation": "SmoothCamera::SmoothCamera",
+                  "type": "behavior"
+                },
+                {
+                  "codeOnly": false,
+                  "defaultValue": "",
+                  "description": "Upward catch-up speed (in ratio per second)",
+                  "longDescription": "",
+                  "name": "UpwardSpeed",
+                  "optional": false,
+                  "supplementaryInformation": "",
+                  "type": "expression"
+                }
+              ],
+              "objectGroups": []
+            },
+            {
+              "description": "Change the camera offset on X axis of an object.",
+              "fullName": "Camera Offset X",
+              "functionType": "Action",
+              "group": "Camera configuration",
+              "name": "SetOffsetX",
+              "private": false,
+              "sentence": "Change the camera offset on X axis of _PARAM0_: _PARAM2_",
+              "events": [
+                {
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [],
+                  "actions": [
+                    {
+                      "type": {
+                        "value": "SmoothCamera::SmoothCamera::SetPropertyCameraOffsetX"
+                      },
+                      "parameters": [
+                        "Object",
+                        "Behavior",
+                        "=",
+                        "GetArgumentAsNumber(\"CameraOffsetX\")"
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "parameters": [
+                {
+                  "codeOnly": false,
+                  "defaultValue": "",
+                  "description": "Object",
+                  "longDescription": "",
+                  "name": "Object",
+                  "optional": false,
+                  "supplementaryInformation": "",
+                  "type": "object"
+                },
+                {
+                  "codeOnly": false,
+                  "defaultValue": "",
+                  "description": "Behavior",
+                  "longDescription": "",
+                  "name": "Behavior",
+                  "optional": false,
+                  "supplementaryInformation": "SmoothCamera::SmoothCamera",
+                  "type": "behavior"
+                },
+                {
+                  "codeOnly": false,
+                  "defaultValue": "",
+                  "description": "Camera offset X",
+                  "longDescription": "",
+                  "name": "CameraOffsetX",
+                  "optional": false,
+                  "supplementaryInformation": "",
+                  "type": "expression"
+                }
+              ],
+              "objectGroups": []
+            },
+            {
+              "description": "Change the camera offset on Y axis of an object.",
+              "fullName": "Camera Offset Y",
+              "functionType": "Action",
+              "group": "Camera configuration",
+              "name": "SetOffsetY",
+              "private": false,
+              "sentence": "Change the camera offset on Y axis of _PARAM0_: _PARAM2_",
+              "events": [
+                {
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [],
+                  "actions": [
+                    {
+                      "type": {
+                        "value": "SmoothCamera::SmoothCamera::SetPropertyCameraOffsetY"
+                      },
+                      "parameters": [
+                        "Object",
+                        "Behavior",
+                        "=",
+                        "GetArgumentAsNumber(\"CameraOffsetY\")"
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "parameters": [
+                {
+                  "codeOnly": false,
+                  "defaultValue": "",
+                  "description": "Object",
+                  "longDescription": "",
+                  "name": "Object",
+                  "optional": false,
+                  "supplementaryInformation": "",
+                  "type": "object"
+                },
+                {
+                  "codeOnly": false,
+                  "defaultValue": "",
+                  "description": "Behavior",
+                  "longDescription": "",
+                  "name": "Behavior",
+                  "optional": false,
+                  "supplementaryInformation": "SmoothCamera::SmoothCamera",
+                  "type": "behavior"
+                },
+                {
+                  "codeOnly": false,
+                  "defaultValue": "",
+                  "description": "Camera offset X",
+                  "longDescription": "",
+                  "name": "CameraOffsetX",
+                  "optional": false,
+                  "supplementaryInformation": "",
+                  "type": "expression"
+                }
+              ],
+              "objectGroups": []
+            },
+            {
+              "description": "Change the camera forecast time (in seconds).",
+              "fullName": "Forecast time",
+              "functionType": "Action",
+              "group": "Camera configuration",
+              "name": "SetForecastTime",
+              "private": false,
+              "sentence": "Change the camera forecast time of _PARAM0_: _PARAM2_",
+              "events": [
+                {
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [],
+                  "actions": [
+                    {
+                      "type": {
+                        "value": "SmoothCamera::SmoothCamera::SetPropertyForecastTime"
+                      },
+                      "parameters": [
+                        "Object",
+                        "Behavior",
+                        "=",
+                        "min(0, GetArgumentAsNumber(\"ForecastTime\"))"
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "parameters": [
+                {
+                  "codeOnly": false,
+                  "defaultValue": "",
+                  "description": "Object",
+                  "longDescription": "",
+                  "name": "Object",
+                  "optional": false,
+                  "supplementaryInformation": "",
+                  "type": "object"
+                },
+                {
+                  "codeOnly": false,
+                  "defaultValue": "",
+                  "description": "Behavior",
+                  "longDescription": "",
+                  "name": "Behavior",
+                  "optional": false,
+                  "supplementaryInformation": "SmoothCamera::SmoothCamera",
+                  "type": "behavior"
+                },
+                {
+                  "codeOnly": false,
+                  "defaultValue": "",
+                  "description": "Forecast time",
+                  "longDescription": "",
+                  "name": "ForecastTime",
+                  "optional": false,
+                  "supplementaryInformation": "",
+                  "type": "expression"
+                }
+              ],
+              "objectGroups": []
+            },
+            {
+              "description": "Change the camera delay (in seconds).",
+              "fullName": "Camera delay",
+              "functionType": "Action",
+              "group": "Camera configuration",
+              "name": "SetCameraDelay",
+              "private": false,
+              "sentence": "Change the camera delay of _PARAM0_: _PARAM2_",
+              "events": [
+                {
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [],
+                  "actions": [
+                    {
+                      "type": {
+                        "value": "SmoothCamera::SmoothCamera::SetPropertyCameraDelay"
+                      },
+                      "parameters": [
+                        "Object",
+                        "Behavior",
+                        "=",
+                        "min(0, GetArgumentAsNumber(\"CameraDelay\"))"
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "parameters": [
+                {
+                  "codeOnly": false,
+                  "defaultValue": "",
+                  "description": "Object",
+                  "longDescription": "",
+                  "name": "Object",
+                  "optional": false,
+                  "supplementaryInformation": "",
+                  "type": "object"
+                },
+                {
+                  "codeOnly": false,
+                  "defaultValue": "",
+                  "description": "Behavior",
+                  "longDescription": "",
+                  "name": "Behavior",
+                  "optional": false,
+                  "supplementaryInformation": "SmoothCamera::SmoothCamera",
+                  "type": "behavior"
+                },
+                {
+                  "codeOnly": false,
+                  "defaultValue": "",
+                  "description": "Camera delay",
+                  "longDescription": "",
+                  "name": "CameraDelay",
+                  "optional": false,
+                  "supplementaryInformation": "",
+                  "type": "expression"
+                }
+              ],
+              "objectGroups": []
+            },
+            {
+              "description": "Return follow free area left border X.",
+              "fullName": "Free area left",
+              "functionType": "Expression",
+              "group": "Private",
+              "name": "FreeAreaLeft",
+              "private": true,
+              "sentence": "",
+              "events": [
+                {
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [],
+                  "actions": [
+                    {
+                      "type": {
+                        "value": "SetReturnNumber"
+                      },
+                      "parameters": [
+                        "Object.Behavior::PropertyForecastedX() + Object.Behavior::PropertyCameraOffsetX() - Object.Behavior::PropertyFollowFreeAreaLeft()"
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "parameters": [
+                {
+                  "codeOnly": false,
+                  "defaultValue": "",
+                  "description": "Object",
+                  "longDescription": "",
+                  "name": "Object",
+                  "optional": false,
+                  "supplementaryInformation": "",
+                  "type": "object"
+                },
+                {
+                  "codeOnly": false,
+                  "defaultValue": "",
+                  "description": "Behavior",
+                  "longDescription": "",
+                  "name": "Behavior",
+                  "optional": false,
+                  "supplementaryInformation": "SmoothCamera::SmoothCamera",
+                  "type": "behavior"
+                }
+              ],
+              "objectGroups": []
+            },
+            {
+              "description": "Return follow free area right border X.",
+              "fullName": "Free area right",
+              "functionType": "Expression",
+              "group": "Private",
+              "name": "FreeAreaRight",
+              "private": true,
+              "sentence": "",
+              "events": [
+                {
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [],
+                  "actions": [
+                    {
+                      "type": {
+                        "value": "SetReturnNumber"
+                      },
+                      "parameters": [
+                        "Object.Behavior::PropertyForecastedX() + Object.Behavior::PropertyCameraOffsetX() + Object.Behavior::PropertyFollowFreeAreaRight()"
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "parameters": [
+                {
+                  "codeOnly": false,
+                  "defaultValue": "",
+                  "description": "Object",
+                  "longDescription": "",
+                  "name": "Object",
+                  "optional": false,
+                  "supplementaryInformation": "",
+                  "type": "object"
+                },
+                {
+                  "codeOnly": false,
+                  "defaultValue": "",
+                  "description": "Behavior",
+                  "longDescription": "",
+                  "name": "Behavior",
+                  "optional": false,
+                  "supplementaryInformation": "SmoothCamera::SmoothCamera",
+                  "type": "behavior"
+                }
+              ],
+              "objectGroups": []
+            },
+            {
+              "description": "Return follow free area bottom border Y.",
+              "fullName": "Free area bottom",
+              "functionType": "Expression",
+              "group": "Private",
+              "name": "FreeAreaBottom",
+              "private": true,
+              "sentence": "",
+              "events": [
+                {
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [],
+                  "actions": [
+                    {
+                      "type": {
+                        "value": "SetReturnNumber"
+                      },
+                      "parameters": [
+                        "Object.Behavior::PropertyForecastedY() + Object.Behavior::PropertyCameraOffsetY() + Object.Behavior::PropertyFollowFreeAreaBottom()"
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "parameters": [
+                {
+                  "codeOnly": false,
+                  "defaultValue": "",
+                  "description": "Object",
+                  "longDescription": "",
+                  "name": "Object",
+                  "optional": false,
+                  "supplementaryInformation": "",
+                  "type": "object"
+                },
+                {
+                  "codeOnly": false,
+                  "defaultValue": "",
+                  "description": "Behavior",
+                  "longDescription": "",
+                  "name": "Behavior",
+                  "optional": false,
+                  "supplementaryInformation": "SmoothCamera::SmoothCamera",
+                  "type": "behavior"
+                }
+              ],
+              "objectGroups": []
+            },
+            {
+              "description": "Return follow free area top border Y.",
+              "fullName": "Free area top",
+              "functionType": "Expression",
+              "group": "Private",
+              "name": "FreeAreaTop",
+              "private": true,
+              "sentence": "",
+              "events": [
+                {
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [],
+                  "actions": [
+                    {
+                      "type": {
+                        "value": "SetReturnNumber"
+                      },
+                      "parameters": [
+                        "Object.Behavior::PropertyForecastedY() + Object.Behavior::PropertyCameraOffsetY() - Object.Behavior::PropertyFollowFreeAreaTop()"
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "parameters": [
+                {
+                  "codeOnly": false,
+                  "defaultValue": "",
+                  "description": "Object",
+                  "longDescription": "",
+                  "name": "Object",
+                  "optional": false,
+                  "supplementaryInformation": "",
+                  "type": "object"
+                },
+                {
+                  "codeOnly": false,
+                  "defaultValue": "",
+                  "description": "Behavior",
+                  "longDescription": "",
+                  "name": "Behavior",
+                  "optional": false,
+                  "supplementaryInformation": "SmoothCamera::SmoothCamera",
+                  "type": "behavior"
+                }
+              ],
+              "objectGroups": []
+            },
+            {
+              "description": "Update delayed position and delayed history. This is called in doStepPreEvents.",
+              "fullName": "Update delayed position",
+              "functionType": "Action",
+              "group": "Private",
+              "name": "UpdateDelayedPosition",
+              "private": true,
+              "sentence": "Update delayed position and delayed history of _PARAM0_",
+              "events": [
+                {
+                  "type": "BuiltinCommonInstructions::Comment",
+                  "color": {
+                    "b": 109,
+                    "g": 230,
+                    "r": 255,
+                    "textB": 0,
+                    "textG": 0,
+                    "textR": 0
+                  },
+                  "comment": "Add the previous position to have enough (2) positions to evaluate the extra delay for waiting mode.",
+                  "comment2": ""
+                },
+                {
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [
+                    {
+                      "type": {
+                        "value": "SmoothCamera::SmoothCamera::IsWaiting"
+                      },
+                      "parameters": [
+                        "Object",
+                        "Behavior",
+                        ""
+                      ]
+                    },
+                    {
+                      "type": {
+                        "value": "Egal"
+                      },
+                      "parameters": [
+                        "Object.VariableChildCount(__SmoothCamera_ObjectTime)",
+                        "=",
+                        "0"
+                      ]
+                    }
+                  ],
+                  "actions": [
+                    {
+                      "type": {
+                        "value": "ObjectVariablePushNumber"
+                      },
+                      "parameters": [
+                        "Object",
+                        "__SmoothCamera_ObjectTime",
+                        "TimeFromStart()"
+                      ]
+                    },
+                    {
+                      "type": {
+                        "value": "ObjectVariablePushNumber"
+                      },
+                      "parameters": [
+                        "Object",
+                        "__SmoothCamera_ObjectX",
+                        "Object.Behavior::PropertyDelayedCenterX()"
+                      ]
+                    },
+                    {
+                      "type": {
+                        "value": "ObjectVariablePushNumber"
+                      },
+                      "parameters": [
+                        "Object",
+                        "__SmoothCamera_ObjectY",
+                        "Object.Behavior::PropertyDelayedCenterY()"
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "BuiltinCommonInstructions::Comment",
+                  "color": {
+                    "b": 109,
+                    "g": 230,
+                    "r": 255,
+                    "textB": 0,
+                    "textG": 0,
+                    "textR": 0
+                  },
+                  "comment": "Use the object center when no delay is asked.",
+                  "comment2": ""
+                },
+                {
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [],
+                  "actions": [
+                    {
+                      "type": {
+                        "value": "SmoothCamera::SmoothCamera::SetPropertyDelayedCenterX"
+                      },
+                      "parameters": [
+                        "Object",
+                        "Behavior",
+                        "=",
+                        "Object.CenterX()"
+                      ]
+                    },
+                    {
+                      "type": {
+                        "value": "SmoothCamera::SmoothCamera::SetPropertyDelayedCenterY"
+                      },
+                      "parameters": [
+                        "Object",
+                        "Behavior",
+                        "=",
+                        "Object.CenterY()"
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [
+                    {
+                      "type": {
+                        "inverted": true,
+                        "value": "SmoothCamera::SmoothCamera::IsDelayed"
+                      },
+                      "parameters": [
+                        "Object",
+                        "Behavior",
+                        ""
+                      ]
+                    }
+                  ],
+                  "actions": [
+                    {
+                      "type": {
+                        "value": "SmoothCamera::SmoothCamera::AddForecastHistoryPosition"
+                      },
+                      "parameters": [
+                        "Object",
+                        "Behavior",
+                        "TimeFromStart()",
+                        "Object.CenterX()",
+                        "Object.CenterY()",
+                        ""
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [
+                    {
+                      "type": {
+                        "value": "BuiltinCommonInstructions::Or"
+                      },
+                      "parameters": [],
+                      "subInstructions": [
+                        {
+                          "type": {
+                            "value": "SmoothCamera::SmoothCamera::IsDelayed"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Behavior",
+                            ""
+                          ]
+                        },
+                        {
+                          "type": {
+                            "value": "SmoothCamera::SmoothCamera::IsWaiting"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Behavior",
+                            ""
+                          ]
+                        }
+                      ]
+                    }
+                  ],
+                  "actions": [
+                    {
+                      "type": {
+                        "value": "ObjectVariablePushNumber"
+                      },
+                      "parameters": [
+                        "Object",
+                        "__SmoothCamera_ObjectTime",
+                        "TimeFromStart()"
+                      ]
+                    },
+                    {
+                      "type": {
+                        "value": "ObjectVariablePushNumber"
+                      },
+                      "parameters": [
+                        "Object",
+                        "__SmoothCamera_ObjectX",
+                        "Object.CenterX()"
+                      ]
+                    },
+                    {
+                      "type": {
+                        "value": "ObjectVariablePushNumber"
+                      },
+                      "parameters": [
+                        "Object",
+                        "__SmoothCamera_ObjectY",
+                        "Object.CenterY()"
+                      ]
+                    }
+                  ],
+                  "events": [
+                    {
+                      "type": "BuiltinCommonInstructions::Comment",
+                      "color": {
+                        "b": 109,
+                        "g": 230,
+                        "r": 255,
+                        "textB": 0,
+                        "textG": 0,
+                        "textR": 0
+                      },
+                      "comment": "Remove history entries that are too old to be useful for delaying and pass it to the history for forecasting.",
+                      "comment2": ""
+                    },
+                    {
+                      "infiniteLoopWarning": true,
+                      "type": "BuiltinCommonInstructions::While",
+                      "whileConditions": [
+                        {
+                          "type": {
+                            "value": "Egal"
+                          },
+                          "parameters": [
+                            "Object.VariableChildCount(__SmoothCamera_ObjectTime)",
+                            ">=",
+                            "2"
+                          ]
+                        },
+                        {
+                          "type": {
+                            "value": "VarObjet"
+                          },
+                          "parameters": [
+                            "Object",
+                            "__SmoothCamera_ObjectTime[1]",
+                            "<",
+                            "TimeFromStart() - Object.Behavior::CurrentDelay()"
+                          ]
+                        }
+                      ],
+                      "conditions": [],
+                      "actions": [
+                        {
+                          "type": {
+                            "value": "SmoothCamera::SmoothCamera::AddForecastHistoryPosition"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Behavior",
+                            "Object.Variable(__SmoothCamera_ObjectTime[0])",
+                            "Object.Variable(__SmoothCamera_ObjectX[0])",
+                            "Object.Variable(__SmoothCamera_ObjectY[0])",
+                            ""
+                          ]
+                        },
+                        {
+                          "type": {
+                            "value": "ObjectVariableRemoveAt"
+                          },
+                          "parameters": [
+                            "Object",
+                            "__SmoothCamera_ObjectTime",
+                            "0"
+                          ]
+                        },
+                        {
+                          "type": {
+                            "value": "ObjectVariableRemoveAt"
+                          },
+                          "parameters": [
+                            "Object",
+                            "__SmoothCamera_ObjectX",
+                            "0"
+                          ]
+                        },
+                        {
+                          "type": {
+                            "value": "ObjectVariableRemoveAt"
+                          },
+                          "parameters": [
+                            "Object",
+                            "__SmoothCamera_ObjectY",
+                            "0"
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "BuiltinCommonInstructions::Comment",
+                      "color": {
+                        "b": 109,
+                        "g": 230,
+                        "r": 255,
+                        "textB": 0,
+                        "textG": 0,
+                        "textR": 0
+                      },
+                      "comment": "Don't move the camera if there is not enough history.",
+                      "comment2": ""
+                    },
+                    {
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [],
+                      "actions": [
+                        {
+                          "type": {
+                            "value": "SmoothCamera::SmoothCamera::SetPropertyDelayedCenterX"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Behavior",
+                            "=",
+                            "Object.Variable(__SmoothCamera_ObjectX[0])"
+                          ]
+                        },
+                        {
+                          "type": {
+                            "value": "SmoothCamera::SmoothCamera::SetPropertyDelayedCenterY"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Behavior",
+                            "=",
+                            "Object.Variable(__SmoothCamera_ObjectY[0])"
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [
+                        {
+                          "type": {
+                            "value": "Egal"
+                          },
+                          "parameters": [
+                            "Object.VariableChildCount(__SmoothCamera_ObjectTime)",
+                            ">=",
+                            "2"
+                          ]
+                        },
+                        {
+                          "type": {
+                            "value": "VarObjet"
+                          },
+                          "parameters": [
+                            "Object",
+                            "__SmoothCamera_ObjectTime[0]",
+                            "<",
+                            "TimeFromStart() - Object.Behavior::CurrentDelay()"
+                          ]
+                        }
+                      ],
+                      "actions": [],
+                      "events": [
+                        {
+                          "type": "BuiltinCommonInstructions::Comment",
+                          "color": {
+                            "b": 109,
+                            "g": 230,
+                            "r": 255,
+                            "textB": 0,
+                            "textG": 0,
+                            "textR": 0
+                          },
+                          "comment": "Add the extra delay that could be needed to respect the speed limit in waiting mode.\n\nspeedRatio = min(speedMaxX / historySpeedX, speedMaxY / historySpeedY)\ndelay += min(0, timeDelta * (1 - speedRatio))",
+                          "comment2": ""
+                        },
+                        {
+                          "type": "BuiltinCommonInstructions::Standard",
+                          "conditions": [
+                            {
+                              "type": {
+                                "value": "SmoothCamera::SmoothCamera::IsWaiting"
+                              },
+                              "parameters": [
+                                "Object",
+                                "Behavior",
+                                ""
+                              ]
+                            }
+                          ],
+                          "actions": [
+                            {
+                              "type": {
+                                "value": "SmoothCamera::SmoothCamera::SetPropertyCameraExtraDelay"
+                              },
+                              "parameters": [
+                                "Object",
+                                "Behavior",
+                                "+",
+                                "max(0, TimeDelta() * (1 - min(Object.Behavior::PropertyWaitingSpeedXMax() * abs(Object.Variable(__SmoothCamera_ObjectX[1]) - Object.Variable(__SmoothCamera_ObjectX[0])), Object.Behavior::PropertyWaitingSpeedYMax() * abs(Object.Variable(__SmoothCamera_ObjectY[1]) - Object.Variable(__SmoothCamera_ObjectY[0]))) / (Object.Variable(__SmoothCamera_ObjectTime[1]) - Object.Variable(__SmoothCamera_ObjectTime[0]))))"
+                              ]
+                            }
+                          ],
+                          "events": [
+                            {
+                              "disabled": true,
+                              "type": "BuiltinCommonInstructions::Standard",
+                              "conditions": [],
+                              "actions": [
+                                {
+                                  "type": {
+                                    "value": "DebuggerTools::ConsoleLog"
+                                  },
+                                  "parameters": [
+                                    "\"Extra delay: \" + ToString(Object.Behavior::PropertyCameraExtraDelay())",
+                                    "\"info\"",
+                                    "\"SmoothCamera\""
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "BuiltinCommonInstructions::Comment",
+                          "color": {
+                            "b": 109,
+                            "g": 230,
+                            "r": 255,
+                            "textB": 0,
+                            "textG": 0,
+                            "textR": 0
+                          },
+                          "comment": "The time with delay is now between the first 2 indexes",
+                          "comment2": ""
+                        },
+                        {
+                          "type": "BuiltinCommonInstructions::Standard",
+                          "conditions": [],
+                          "actions": [
+                            {
+                              "type": {
+                                "value": "SmoothCamera::SmoothCamera::SetPropertyDelayedCenterX"
+                              },
+                              "parameters": [
+                                "Object",
+                                "Behavior",
+                                "=",
+                                "lerp(Object.Variable(__SmoothCamera_ObjectX[1]), Object.Variable(__SmoothCamera_ObjectX[0]), ((TimeFromStart() - Object.Behavior::CurrentDelay()) - Object.Variable(__SmoothCamera_ObjectTime[1])) / (Object.Variable(__SmoothCamera_ObjectTime[0]) - Object.Variable(__SmoothCamera_ObjectTime[1])))"
+                              ]
+                            },
+                            {
+                              "type": {
+                                "value": "SmoothCamera::SmoothCamera::SetPropertyDelayedCenterY"
+                              },
+                              "parameters": [
+                                "Object",
+                                "Behavior",
+                                "=",
+                                "lerp(Object.Variable(__SmoothCamera_ObjectY[1]), Object.Variable(__SmoothCamera_ObjectY[0]), ((TimeFromStart() - Object.Behavior::CurrentDelay()) - Object.Variable(__SmoothCamera_ObjectTime[1])) / (Object.Variable(__SmoothCamera_ObjectTime[0]) - Object.Variable(__SmoothCamera_ObjectTime[1])))"
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [
+                    {
+                      "type": {
+                        "inverted": true,
+                        "value": "SmoothCamera::SmoothCamera::IsDelayed"
+                      },
+                      "parameters": [
+                        "Object",
+                        "Behavior",
+                        ""
+                      ]
+                    },
+                    {
+                      "type": {
+                        "inverted": true,
+                        "value": "SmoothCamera::SmoothCamera::IsWaiting"
+                      },
+                      "parameters": [
+                        "Object",
+                        "Behavior",
+                        ""
+                      ]
+                    }
+                  ],
+                  "actions": [
+                    {
+                      "type": {
+                        "value": "ObjectVariableClearChildren"
+                      },
+                      "parameters": [
+                        "Object",
+                        "__SmoothCamera_ObjectTime"
+                      ]
+                    },
+                    {
+                      "type": {
+                        "value": "ObjectVariableClearChildren"
+                      },
+                      "parameters": [
+                        "Object",
+                        "__SmoothCamera_ObjectX"
+                      ]
+                    },
+                    {
+                      "type": {
+                        "value": "ObjectVariableClearChildren"
+                      },
+                      "parameters": [
+                        "Object",
+                        "__SmoothCamera_ObjectY"
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [
+                    {
+                      "type": {
+                        "inverted": true,
+                        "value": "SmoothCamera::SmoothCamera::IsWaiting"
+                      },
+                      "parameters": [
+                        "Object",
+                        "Behavior",
+                        ""
+                      ]
+                    },
+                    {
+                      "type": {
+                        "value": "BuiltinCommonInstructions::Once"
+                      },
+                      "parameters": []
+                    }
+                  ],
+                  "actions": [
+                    {
+                      "type": {
+                        "value": "SmoothCamera::SmoothCamera::SetPropertyCameraDelayCatchUpSpeed"
+                      },
+                      "parameters": [
+                        "Object",
+                        "Behavior",
+                        "=",
+                        "Object.Behavior::PropertyCameraExtraDelay() / Object.Behavior::PropertyCameraDelayCatchUpDuration()"
+                      ]
+                    }
+                  ],
+                  "events": [
+                    {
+                      "disabled": true,
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [],
+                      "actions": [
+                        {
+                          "type": {
+                            "value": "DebuggerTools::ConsoleLog"
+                          },
+                          "parameters": [
+                            "\"Start to catch up\"",
+                            "\"info\"",
+                            "\"SmoothCamera\""
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [
+                    {
+                      "type": {
+                        "inverted": true,
+                        "value": "SmoothCamera::SmoothCamera::IsWaiting"
+                      },
+                      "parameters": [
+                        "Object",
+                        "Behavior",
+                        ""
+                      ]
+                    },
+                    {
+                      "type": {
+                        "value": "SmoothCamera::SmoothCamera::PropertyCameraExtraDelay"
+                      },
+                      "parameters": [
+                        "Object",
+                        "Behavior",
+                        ">",
+                        "0"
+                      ]
+                    }
+                  ],
+                  "actions": [
+                    {
+                      "type": {
+                        "value": "SmoothCamera::SmoothCamera::SetPropertyCameraExtraDelay"
+                      },
+                      "parameters": [
+                        "Object",
+                        "Behavior",
+                        "=",
+                        "max(0, Object.Behavior::PropertyCameraExtraDelay() -Object.Behavior::PropertyCameraDelayCatchUpSpeed() * TimeDelta())"
+                      ]
+                    }
+                  ],
+                  "events": [
+                    {
+                      "disabled": true,
+                      "type": "BuiltinCommonInstructions::Standard",
+                      "conditions": [],
+                      "actions": [
+                        {
+                          "type": {
+                            "value": "DebuggerTools::ConsoleLog"
+                          },
+                          "parameters": [
+                            "\"Catching up delay: \" + ToString(Object.Behavior::PropertyCameraExtraDelay())",
+                            "\"info\"",
+                            "\"SmoothCamera\""
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "parameters": [
+                {
+                  "codeOnly": false,
+                  "defaultValue": "",
+                  "description": "Object",
+                  "longDescription": "",
+                  "name": "Object",
+                  "optional": false,
+                  "supplementaryInformation": "",
+                  "type": "object"
+                },
+                {
+                  "codeOnly": false,
+                  "defaultValue": "",
+                  "description": "Behavior",
+                  "longDescription": "",
+                  "name": "Behavior",
+                  "optional": false,
+                  "supplementaryInformation": "SmoothCamera::SmoothCamera",
+                  "type": "behavior"
+                }
+              ],
+              "objectGroups": []
+            },
+            {
+              "description": "Check if the camera following target is delayed from the object.",
+              "fullName": "Camera is delayed",
+              "functionType": "Condition",
+              "group": "",
+              "name": "IsDelayed",
+              "private": true,
+              "sentence": "The camera of _PARAM0_ is delayed",
+              "events": [
+                {
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [
+                    {
+                      "type": {
+                        "value": "Egal"
+                      },
+                      "parameters": [
+                        "Object.Behavior::CurrentDelay()",
+                        ">",
+                        "0"
+                      ]
+                    }
+                  ],
+                  "actions": [
+                    {
+                      "type": {
+                        "value": "SetReturnBoolean"
+                      },
+                      "parameters": [
+                        "True"
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "parameters": [
+                {
+                  "codeOnly": false,
+                  "defaultValue": "",
+                  "description": "Object",
+                  "longDescription": "",
+                  "name": "Object",
+                  "optional": false,
+                  "supplementaryInformation": "",
+                  "type": "object"
+                },
+                {
+                  "codeOnly": false,
+                  "defaultValue": "",
+                  "description": "Behavior",
+                  "longDescription": "",
+                  "name": "Behavior",
+                  "optional": false,
+                  "supplementaryInformation": "SmoothCamera::SmoothCamera",
+                  "type": "behavior"
+                }
+              ],
+              "objectGroups": []
+            },
+            {
+              "description": "Return the current camera delay.",
+              "fullName": "Current delay",
+              "functionType": "Expression",
+              "group": "",
+              "name": "CurrentDelay",
+              "private": true,
+              "sentence": "",
+              "events": [
+                {
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [],
+                  "actions": [
+                    {
+                      "type": {
+                        "value": "SetReturnNumber"
+                      },
+                      "parameters": [
+                        "Object.Behavior::PropertyCameraDelay() + Object.Behavior::PropertyCameraExtraDelay()"
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "parameters": [
+                {
+                  "codeOnly": false,
+                  "defaultValue": "",
+                  "description": "Object",
+                  "longDescription": "",
+                  "name": "Object",
+                  "optional": false,
+                  "supplementaryInformation": "",
+                  "type": "object"
+                },
+                {
+                  "codeOnly": false,
+                  "defaultValue": "",
+                  "description": "Behavior",
+                  "longDescription": "",
+                  "name": "Behavior",
+                  "optional": false,
+                  "supplementaryInformation": "SmoothCamera::SmoothCamera",
+                  "type": "behavior"
+                }
+              ],
+              "objectGroups": []
+            },
+            {
+              "description": "Check if the camera following is waiting at a reduced speed.",
+              "fullName": "Camera is waiting",
+              "functionType": "Condition",
+              "group": "",
+              "name": "IsWaiting",
+              "private": true,
+              "sentence": "The camera of _PARAM0_ is waiting",
+              "events": [
+                {
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [
+                    {
+                      "type": {
+                        "value": "SmoothCamera::SmoothCamera::PropertyWaitingEnd"
+                      },
+                      "parameters": [
+                        "Object",
+                        "Behavior",
+                        ">",
+                        "TimeFromStart()"
+                      ]
+                    }
+                  ],
+                  "actions": [
+                    {
+                      "type": {
+                        "value": "SetReturnBoolean"
+                      },
+                      "parameters": [
+                        "True"
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "parameters": [
+                {
+                  "codeOnly": false,
+                  "defaultValue": "",
+                  "description": "Object",
+                  "longDescription": "",
+                  "name": "Object",
+                  "optional": false,
+                  "supplementaryInformation": "",
+                  "type": "object"
+                },
+                {
+                  "codeOnly": false,
+                  "defaultValue": "",
+                  "description": "Behavior",
+                  "longDescription": "",
+                  "name": "Behavior",
+                  "optional": false,
+                  "supplementaryInformation": "SmoothCamera::SmoothCamera",
+                  "type": "behavior"
+                }
+              ],
+              "objectGroups": []
+            },
+            {
+              "description": "Add a position to the history for forecasting. This is called 2 times in UpadteDelayedPosition.",
+              "fullName": "Add forecast history position",
+              "functionType": "Action",
+              "group": "Private",
+              "name": "AddForecastHistoryPosition",
+              "private": true,
+              "sentence": "Add the time:_PARAM2_ and position: _PARAM3_; _PARAM4_ to the forecast history of _PARAM0_",
+              "events": [
+                {
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [
+                    {
+                      "type": {
+                        "value": "BuiltinCommonInstructions::Or"
+                      },
+                      "parameters": [],
+                      "subInstructions": [
+                        {
+                          "type": {
+                            "value": "SmoothCamera::SmoothCamera::PropertyForecastHistoryDuration"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Behavior",
+                            ">",
+                            "0"
+                          ]
+                        },
+                        {
+                          "type": {
+                            "value": "SmoothCamera::SmoothCamera::PropertyForecastTime"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Behavior",
+                            ">",
+                            "0"
+                          ]
+                        }
+                      ]
+                    }
+                  ],
+                  "actions": [
+                    {
+                      "type": {
+                        "value": "ObjectVariablePushNumber"
+                      },
+                      "parameters": [
+                        "Object",
+                        "__SmoothCamera_ForecastHistoryTime",
+                        "GetArgumentAsNumber(\"Time\")"
+                      ]
+                    },
+                    {
+                      "type": {
+                        "value": "ObjectVariablePushNumber"
+                      },
+                      "parameters": [
+                        "Object",
+                        "__SmoothCamera_ForecastHistoryX",
+                        "GetArgumentAsNumber(\"ObjectX\")"
+                      ]
+                    },
+                    {
+                      "type": {
+                        "value": "ObjectVariablePushNumber"
+                      },
+                      "parameters": [
+                        "Object",
+                        "__SmoothCamera_ForecastHistoryY",
+                        "GetArgumentAsNumber(\"ObjectY\")"
+                      ]
+                    }
+                  ],
+                  "events": [
+                    {
+                      "type": "BuiltinCommonInstructions::Comment",
+                      "color": {
+                        "b": 109,
+                        "g": 230,
+                        "r": 255,
+                        "textB": 0,
+                        "textG": 0,
+                        "textR": 0
+                      },
+                      "comment": "Remove history entries that are too old to be useful.\nKeep at least 2 positions because no forecast can be done with less positions.",
+                      "comment2": ""
+                    },
+                    {
+                      "infiniteLoopWarning": true,
+                      "type": "BuiltinCommonInstructions::While",
+                      "whileConditions": [
+                        {
+                          "type": {
+                            "value": "Egal"
+                          },
+                          "parameters": [
+                            "Object.VariableChildCount(__SmoothCamera_ForecastHistoryTime)",
+                            ">=",
+                            "3"
+                          ]
+                        },
+                        {
+                          "type": {
+                            "value": "VarObjet"
+                          },
+                          "parameters": [
+                            "Object",
+                            "__SmoothCamera_ForecastHistoryTime[0]",
+                            "<",
+                            "TimeFromStart() - Object.Behavior::PropertyCameraDelay() - Object.Behavior::PropertyCameraExtraDelay() - Object.Behavior::PropertyForecastHistoryDuration()"
+                          ]
+                        }
+                      ],
+                      "conditions": [],
+                      "actions": [
+                        {
+                          "type": {
+                            "value": "ObjectVariableRemoveAt"
+                          },
+                          "parameters": [
+                            "Object",
+                            "__SmoothCamera_ForecastHistoryTime",
+                            "0"
+                          ]
+                        },
+                        {
+                          "type": {
+                            "value": "ObjectVariableRemoveAt"
+                          },
+                          "parameters": [
+                            "Object",
+                            "__SmoothCamera_ForecastHistoryX",
+                            "0"
+                          ]
+                        },
+                        {
+                          "type": {
+                            "value": "ObjectVariableRemoveAt"
+                          },
+                          "parameters": [
+                            "Object",
+                            "__SmoothCamera_ForecastHistoryY",
+                            "0"
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "parameters": [
+                {
+                  "codeOnly": false,
+                  "defaultValue": "",
+                  "description": "Object",
+                  "longDescription": "",
+                  "name": "Object",
+                  "optional": false,
+                  "supplementaryInformation": "",
+                  "type": "object"
+                },
+                {
+                  "codeOnly": false,
+                  "defaultValue": "",
+                  "description": "Behavior",
+                  "longDescription": "",
+                  "name": "Behavior",
+                  "optional": false,
+                  "supplementaryInformation": "SmoothCamera::SmoothCamera",
+                  "type": "behavior"
+                },
+                {
+                  "codeOnly": false,
+                  "defaultValue": "",
+                  "description": "Time",
+                  "longDescription": "",
+                  "name": "Time",
+                  "optional": false,
+                  "supplementaryInformation": "",
+                  "type": "expression"
+                },
+                {
+                  "codeOnly": false,
+                  "defaultValue": "",
+                  "description": "Object X",
+                  "longDescription": "",
+                  "name": "ObjectX",
+                  "optional": false,
+                  "supplementaryInformation": "",
+                  "type": "expression"
+                },
+                {
+                  "codeOnly": false,
+                  "defaultValue": "",
+                  "description": "Object Y",
+                  "longDescription": "",
+                  "name": "ObjectY",
+                  "optional": false,
+                  "supplementaryInformation": "",
+                  "type": "expression"
+                }
+              ],
+              "objectGroups": []
+            },
+            {
+              "description": "Update forecasted position. This is called in doStepPreEvents.",
+              "fullName": "Update forecasted position",
+              "functionType": "Action",
+              "group": "Private",
+              "name": "UpdateForecastedPosition",
+              "private": true,
+              "sentence": "Update forecasted position of _PARAM0_",
+              "events": [
+                {
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [],
+                  "actions": [
+                    {
+                      "type": {
+                        "value": "SmoothCamera::SmoothCamera::SetPropertyForecastedX"
+                      },
+                      "parameters": [
+                        "Object",
+                        "Behavior",
+                        "=",
+                        "Object.Behavior::PropertyDelayedCenterX()"
+                      ]
+                    },
+                    {
+                      "type": {
+                        "value": "SmoothCamera::SmoothCamera::SetPropertyForecastedY"
+                      },
+                      "parameters": [
+                        "Object",
+                        "Behavior",
+                        "=",
+                        "Object.Behavior::PropertyDelayedCenterY()"
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "BuiltinCommonInstructions::Comment",
+                  "color": {
+                    "b": 109,
+                    "g": 230,
+                    "r": 255,
+                    "textB": 0,
+                    "textG": 0,
+                    "textR": 0
+                  },
+                  "comment": "Simple linear regression\ny = A * x + B\n\nA = Covariance / VarianceX\nB = MeanY - A * MeanX\n\nNote than we could use only one position every N positions to reduce the process time,\nbut if we really need efficient process JavaScript and circular queues are a must.",
+                  "comment2": ""
+                },
+                {
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [
+                    {
+                      "type": {
+                        "value": "Egal"
+                      },
+                      "parameters": [
+                        "Object.VariableChildCount(__SmoothCamera_ForecastHistoryTime)",
+                        ">=",
+                        "2"
+                      ]
+                    },
+                    {
+                      "type": {
+                        "value": "BuiltinCommonInstructions::Or"
+                      },
+                      "parameters": [],
+                      "subInstructions": [
+                        {
+                          "type": {
+                            "value": "SmoothCamera::SmoothCamera::PropertyForecastHistoryDuration"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Behavior",
+                            ">",
+                            "0"
+                          ]
+                        },
+                        {
+                          "type": {
+                            "value": "SmoothCamera::SmoothCamera::PropertyForecastTime"
+                          },
+                          "parameters": [
+                            "Object",
+                            "Behavior",
+                            ">",
+                            "0"
+                          ]
+                        }
+                      ]
+                    }
+                  ],
+                  "actions": [],
+                  "events": [
+                    {
+                      "colorB": 228,
+                      "colorG": 176,
+                      "colorR": 74,
+                      "creationTime": 0,
+                      "name": "Mean X",
+                      "source": "",
+                      "type": "BuiltinCommonInstructions::Group",
+                      "events": [
+                        {
+                          "type": "BuiltinCommonInstructions::Standard",
+                          "conditions": [],
+                          "actions": [
+                            {
+                              "type": {
+                                "value": "SmoothCamera::SmoothCamera::SetPropertyForecastHistoryMeanX"
+                              },
+                              "parameters": [
+                                "Object",
+                                "Behavior",
+                                "=",
+                                "0"
+                              ]
+                            },
+                            {
+                              "type": {
+                                "value": "SmoothCamera::SmoothCamera::SetPropertyIndex"
+                              },
+                              "parameters": [
+                                "Object",
+                                "Behavior",
+                                "=",
+                                "0"
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "BuiltinCommonInstructions::Repeat",
+                          "repeatExpression": "Object.VariableChildCount(__SmoothCamera_ForecastHistoryX)",
+                          "conditions": [],
+                          "actions": [
+                            {
+                              "type": {
+                                "value": "SmoothCamera::SmoothCamera::SetPropertyForecastHistoryMeanX"
+                              },
+                              "parameters": [
+                                "Object",
+                                "Behavior",
+                                "+",
+                                "Object.Variable(__SmoothCamera_ForecastHistoryX[Object.Behavior::PropertyIndex()])"
+                              ]
+                            },
+                            {
+                              "type": {
+                                "value": "SmoothCamera::SmoothCamera::SetPropertyIndex"
+                              },
+                              "parameters": [
+                                "Object",
+                                "Behavior",
+                                "+",
+                                "1"
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "BuiltinCommonInstructions::Standard",
+                          "conditions": [],
+                          "actions": [
+                            {
+                              "type": {
+                                "value": "SmoothCamera::SmoothCamera::SetPropertyForecastHistoryMeanX"
+                              },
+                              "parameters": [
+                                "Object",
+                                "Behavior",
+                                "/",
+                                "Object.VariableChildCount(__SmoothCamera_ForecastHistoryX)"
+                              ]
+                            }
+                          ]
+                        }
+                      ],
+                      "parameters": []
+                    },
+                    {
+                      "colorB": 228,
+                      "colorG": 176,
+                      "colorR": 74,
+                      "creationTime": 0,
+                      "name": "Mean Y",
+                      "source": "",
+                      "type": "BuiltinCommonInstructions::Group",
+                      "events": [
+                        {
+                          "type": "BuiltinCommonInstructions::Standard",
+                          "conditions": [],
+                          "actions": [
+                            {
+                              "type": {
+                                "value": "SmoothCamera::SmoothCamera::SetPropertyForecastHistoryMeanY"
+                              },
+                              "parameters": [
+                                "Object",
+                                "Behavior",
+                                "=",
+                                "0"
+                              ]
+                            },
+                            {
+                              "type": {
+                                "value": "SmoothCamera::SmoothCamera::SetPropertyIndex"
+                              },
+                              "parameters": [
+                                "Object",
+                                "Behavior",
+                                "=",
+                                "0"
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "BuiltinCommonInstructions::Repeat",
+                          "repeatExpression": "Object.VariableChildCount(__SmoothCamera_ForecastHistoryY)",
+                          "conditions": [],
+                          "actions": [
+                            {
+                              "type": {
+                                "value": "SmoothCamera::SmoothCamera::SetPropertyForecastHistoryMeanY"
+                              },
+                              "parameters": [
+                                "Object",
+                                "Behavior",
+                                "+",
+                                "Object.Variable(__SmoothCamera_ForecastHistoryY[Object.Behavior::PropertyIndex()])"
+                              ]
+                            },
+                            {
+                              "type": {
+                                "value": "SmoothCamera::SmoothCamera::SetPropertyIndex"
+                              },
+                              "parameters": [
+                                "Object",
+                                "Behavior",
+                                "+",
+                                "1"
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "BuiltinCommonInstructions::Standard",
+                          "conditions": [],
+                          "actions": [
+                            {
+                              "type": {
+                                "value": "SmoothCamera::SmoothCamera::SetPropertyForecastHistoryMeanY"
+                              },
+                              "parameters": [
+                                "Object",
+                                "Behavior",
+                                "/",
+                                "Object.VariableChildCount(__SmoothCamera_ForecastHistoryY)"
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "disabled": true,
+                          "type": "BuiltinCommonInstructions::Standard",
+                          "conditions": [],
+                          "actions": [
+                            {
+                              "type": {
+                                "value": "DebuggerTools::ConsoleLog"
+                              },
+                              "parameters": [
+                                "\"Mean: \" + ToString(Object.Behavior::PropertyForecastHistoryMeanX()) + \" \" + ToString(Object.Behavior::PropertyForecastHistoryMeanY())",
+                                "",
+                                ""
+                              ]
+                            }
+                          ]
+                        }
+                      ],
+                      "parameters": []
+                    },
+                    {
+                      "colorB": 228,
+                      "colorG": 176,
+                      "colorR": 74,
+                      "creationTime": 0,
+                      "name": "Variance and Covariance",
+                      "source": "",
+                      "type": "BuiltinCommonInstructions::Group",
+                      "events": [
+                        {
+                          "type": "BuiltinCommonInstructions::Comment",
+                          "color": {
+                            "b": 109,
+                            "g": 230,
+                            "r": 255,
+                            "textB": 0,
+                            "textG": 0,
+                            "textR": 0
+                          },
+                          "comment": "VarianceX = sum((X[i] - MeanX)²)\nVarianceY = sum((Y[i] - MeanY)²)\nCovariance = sum((X[i] - MeanX) * (Y[i] - MeanY))",
+                          "comment2": ""
+                        },
+                        {
+                          "type": "BuiltinCommonInstructions::Standard",
+                          "conditions": [],
+                          "actions": [
+                            {
+                              "type": {
+                                "value": "SmoothCamera::SmoothCamera::SetPropertyForecastHistoryVarianceX"
+                              },
+                              "parameters": [
+                                "Object",
+                                "Behavior",
+                                "=",
+                                "0"
+                              ]
+                            },
+                            {
+                              "type": {
+                                "value": "SmoothCamera::SmoothCamera::SetPropertyForecastHistoryVarianceY"
+                              },
+                              "parameters": [
+                                "Object",
+                                "Behavior",
+                                "=",
+                                "0"
+                              ]
+                            },
+                            {
+                              "type": {
+                                "value": "SmoothCamera::SmoothCamera::SetPropertyForecastHistoryCovariance"
+                              },
+                              "parameters": [
+                                "Object",
+                                "Behavior",
+                                "=",
+                                "0"
+                              ]
+                            },
+                            {
+                              "type": {
+                                "value": "SmoothCamera::SmoothCamera::SetPropertyIndex"
+                              },
+                              "parameters": [
+                                "Object",
+                                "Behavior",
+                                "=",
+                                "0"
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "BuiltinCommonInstructions::Repeat",
+                          "repeatExpression": "Object.VariableChildCount(__SmoothCamera_ForecastHistoryX)",
+                          "conditions": [],
+                          "actions": [
+                            {
+                              "type": {
+                                "value": "SmoothCamera::SmoothCamera::SetPropertyForecastHistoryVarianceX"
+                              },
+                              "parameters": [
+                                "Object",
+                                "Behavior",
+                                "+",
+                                "pow(Object.Variable(__SmoothCamera_ForecastHistoryX[Object.Behavior::PropertyIndex()]) - Object.Behavior::PropertyForecastHistoryMeanX(), 2)"
+                              ]
+                            },
+                            {
+                              "type": {
+                                "value": "SmoothCamera::SmoothCamera::SetPropertyForecastHistoryVarianceY"
+                              },
+                              "parameters": [
+                                "Object",
+                                "Behavior",
+                                "+",
+                                "pow(Object.Variable(__SmoothCamera_ForecastHistoryY[Object.Behavior::PropertyIndex()]) - Object.Behavior::PropertyForecastHistoryMeanY(), 2)"
+                              ]
+                            },
+                            {
+                              "type": {
+                                "value": "SmoothCamera::SmoothCamera::SetPropertyForecastHistoryCovariance"
+                              },
+                              "parameters": [
+                                "Object",
+                                "Behavior",
+                                "+",
+                                "(Object.Variable(__SmoothCamera_ForecastHistoryX[Object.Behavior::PropertyIndex()]) - Object.Behavior::PropertyForecastHistoryMeanX())\n*\n(Object.Variable(__SmoothCamera_ForecastHistoryY[Object.Behavior::PropertyIndex()]) - Object.Behavior::PropertyForecastHistoryMeanY())"
+                              ]
+                            },
+                            {
+                              "type": {
+                                "value": "SmoothCamera::SmoothCamera::SetPropertyIndex"
+                              },
+                              "parameters": [
+                                "Object",
+                                "Behavior",
+                                "+",
+                                "1"
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "disabled": true,
+                          "type": "BuiltinCommonInstructions::Standard",
+                          "conditions": [],
+                          "actions": [
+                            {
+                              "type": {
+                                "value": "DebuggerTools::ConsoleLog"
+                              },
+                              "parameters": [
+                                "\"Variances: \" + ToString(Object.Behavior::PropertyForecastHistoryVarianceX()) + \" \" + ToString(Object.Behavior::PropertyForecastHistoryVarianceY()) + \" \" + ToString(Object.Behavior::PropertyForecastHistoryCovariance())",
+                                "\"info\"",
+                                "\"SmoothCamera\""
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "BuiltinCommonInstructions::Standard",
+                          "conditions": [
+                            {
+                              "type": {
+                                "value": "Egal"
+                              },
+                              "parameters": [
+                                "abs(Object.Behavior::PropertyForecastHistoryVarianceX())",
+                                "<",
+                                "1"
+                              ]
+                            },
+                            {
+                              "type": {
+                                "value": "Egal"
+                              },
+                              "parameters": [
+                                "abs(Object.Behavior::PropertyForecastHistoryVarianceY())",
+                                "<",
+                                "1"
+                              ]
+                            }
+                          ],
+                          "actions": [
+                            {
+                              "type": {
+                                "value": "SmoothCamera::SmoothCamera::SetPropertyForecastedX"
+                              },
+                              "parameters": [
+                                "Object",
+                                "Behavior",
+                                "=",
+                                "Object.Behavior::PropertyDelayedCenterX()"
+                              ]
+                            },
+                            {
+                              "type": {
+                                "value": "SmoothCamera::SmoothCamera::SetPropertyForecastedY"
+                              },
+                              "parameters": [
+                                "Object",
+                                "Behavior",
+                                "=",
+                                "Object.Behavior::PropertyDelayedCenterY()"
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "BuiltinCommonInstructions::Standard",
+                          "conditions": [
+                            {
+                              "type": {
+                                "value": "BuiltinCommonInstructions::Or"
+                              },
+                              "parameters": [],
+                              "subInstructions": [
+                                {
+                                  "type": {
+                                    "value": "Egal"
+                                  },
+                                  "parameters": [
+                                    "abs(Object.Behavior::PropertyForecastHistoryVarianceX())",
+                                    ">=",
+                                    "1"
+                                  ]
+                                },
+                                {
+                                  "type": {
+                                    "value": "Egal"
+                                  },
+                                  "parameters": [
+                                    "abs(Object.Behavior::PropertyForecastHistoryVarianceY())",
+                                    ">=",
+                                    "1"
+                                  ]
+                                }
+                              ]
+                            }
+                          ],
+                          "actions": [],
+                          "events": [
+                            {
+                              "colorB": 228,
+                              "colorG": 176,
+                              "colorR": 74,
+                              "creationTime": 0,
+                              "name": "Linear function parameters",
+                              "source": "",
+                              "type": "BuiltinCommonInstructions::Group",
+                              "events": [
+                                {
+                                  "type": "BuiltinCommonInstructions::Comment",
+                                  "color": {
+                                    "b": 109,
+                                    "g": 230,
+                                    "r": 255,
+                                    "textB": 0,
+                                    "textG": 0,
+                                    "textR": 0
+                                  },
+                                  "comment": "y = A * x + B\n\nA = Covariance / VarianceX\nB = MeanY - A * MeanX",
+                                  "comment2": ""
+                                },
+                                {
+                                  "type": "BuiltinCommonInstructions::Standard",
+                                  "conditions": [
+                                    {
+                                      "type": {
+                                        "value": "Egal"
+                                      },
+                                      "parameters": [
+                                        "abs(Object.Behavior::PropertyForecastHistoryVarianceX())",
+                                        ">=",
+                                        "abs(Object.Behavior::PropertyForecastHistoryVarianceY())"
+                                      ]
+                                    }
+                                  ],
+                                  "actions": [
+                                    {
+                                      "type": {
+                                        "value": "SmoothCamera::SmoothCamera::SetPropertyForecastHistoryLinearA"
+                                      },
+                                      "parameters": [
+                                        "Object",
+                                        "Behavior",
+                                        "=",
+                                        "Object.Behavior::PropertyForecastHistoryCovariance() / Object.Behavior::PropertyForecastHistoryVarianceX()"
+                                      ]
+                                    },
+                                    {
+                                      "type": {
+                                        "value": "SmoothCamera::SmoothCamera::SetPropertyForecastHistoryLinearB"
+                                      },
+                                      "parameters": [
+                                        "Object",
+                                        "Behavior",
+                                        "=",
+                                        "Object.Behavior::PropertyForecastHistoryMeanY() - Object.Behavior::PropertyForecastHistoryLinearA() * Object.Behavior::PropertyForecastHistoryMeanX()"
+                                      ]
+                                    }
+                                  ],
+                                  "events": [
+                                    {
+                                      "disabled": true,
+                                      "type": "BuiltinCommonInstructions::Standard",
+                                      "conditions": [],
+                                      "actions": [
+                                        {
+                                          "type": {
+                                            "value": "DebuggerTools::ConsoleLog"
+                                          },
+                                          "parameters": [
+                                            "\"Linear: \" + ToString(Object.Behavior::PropertyForecastHistoryLinearA()) + \" \" + ToString(Object.Behavior::PropertyForecastHistoryLinearB())",
+                                            "\"info\"",
+                                            "\"SmoothCamera\""
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "colorB": 228,
+                                      "colorG": 176,
+                                      "colorR": 74,
+                                      "creationTime": 0,
+                                      "name": "Projection",
+                                      "source": "",
+                                      "type": "BuiltinCommonInstructions::Group",
+                                      "events": [
+                                        {
+                                          "type": "BuiltinCommonInstructions::Standard",
+                                          "conditions": [],
+                                          "actions": [
+                                            {
+                                              "type": {
+                                                "value": "SmoothCamera::SmoothCamera::ProjectHistoryEnds"
+                                              },
+                                              "parameters": [
+                                                "Object",
+                                                "Behavior",
+                                                "Object.Variable(__SmoothCamera_ForecastHistoryX[0])",
+                                                "Object.Variable(__SmoothCamera_ForecastHistoryY[0])",
+                                                "Object.Variable(__SmoothCamera_ForecastHistoryX[Object.VariableChildCount(__SmoothCamera_ForecastHistoryX) - 1])",
+                                                "Object.Variable(__SmoothCamera_ForecastHistoryY[Object.VariableChildCount(__SmoothCamera_ForecastHistoryY) - 1])",
+                                                ""
+                                              ]
+                                            }
+                                          ]
+                                        }
+                                      ],
+                                      "parameters": []
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "BuiltinCommonInstructions::Comment",
+                                  "color": {
+                                    "b": 109,
+                                    "g": 230,
+                                    "r": 255,
+                                    "textB": 0,
+                                    "textG": 0,
+                                    "textR": 0
+                                  },
+                                  "comment": "Axis permutation to avoid a ratio between 2 numbers near 0.",
+                                  "comment2": ""
+                                },
+                                {
+                                  "type": "BuiltinCommonInstructions::Standard",
+                                  "conditions": [
+                                    {
+                                      "type": {
+                                        "value": "Egal"
+                                      },
+                                      "parameters": [
+                                        "abs(Object.Behavior::PropertyForecastHistoryVarianceX())",
+                                        "<",
+                                        "abs(Object.Behavior::PropertyForecastHistoryVarianceY())"
+                                      ]
+                                    }
+                                  ],
+                                  "actions": [
+                                    {
+                                      "type": {
+                                        "value": "SmoothCamera::SmoothCamera::SetPropertyForecastHistoryLinearA"
+                                      },
+                                      "parameters": [
+                                        "Object",
+                                        "Behavior",
+                                        "=",
+                                        "Object.Behavior::PropertyForecastHistoryCovariance() / Object.Behavior::PropertyForecastHistoryVarianceY()"
+                                      ]
+                                    },
+                                    {
+                                      "type": {
+                                        "value": "SmoothCamera::SmoothCamera::SetPropertyForecastHistoryLinearB"
+                                      },
+                                      "parameters": [
+                                        "Object",
+                                        "Behavior",
+                                        "=",
+                                        "Object.Behavior::PropertyForecastHistoryMeanX() - Object.Behavior::PropertyForecastHistoryLinearA() * Object.Behavior::PropertyForecastHistoryMeanY()"
+                                      ]
+                                    }
+                                  ],
+                                  "events": [
+                                    {
+                                      "disabled": true,
+                                      "type": "BuiltinCommonInstructions::Standard",
+                                      "conditions": [],
+                                      "actions": [
+                                        {
+                                          "type": {
+                                            "value": "DebuggerTools::ConsoleLog"
+                                          },
+                                          "parameters": [
+                                            "\"Linear: \" + ToString(Object.Behavior::PropertyForecastHistoryLinearA()) + \" \" + ToString(Object.Behavior::PropertyForecastHistoryLinearB())",
+                                            "\"info\"",
+                                            "\"SmoothCamera\""
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "colorB": 228,
+                                      "colorG": 176,
+                                      "colorR": 74,
+                                      "creationTime": 0,
+                                      "name": "Projection",
+                                      "source": "",
+                                      "type": "BuiltinCommonInstructions::Group",
+                                      "events": [
+                                        {
+                                          "type": "BuiltinCommonInstructions::Standard",
+                                          "conditions": [],
+                                          "actions": [
+                                            {
+                                              "type": {
+                                                "value": "SmoothCamera::SmoothCamera::ProjectHistoryEnds"
+                                              },
+                                              "parameters": [
+                                                "Object",
+                                                "Behavior",
+                                                "Object.Variable(__SmoothCamera_ForecastHistoryY[0])",
+                                                "Object.Variable(__SmoothCamera_ForecastHistoryX[0])",
+                                                "Object.Variable(__SmoothCamera_ForecastHistoryY[Object.VariableChildCount(__SmoothCamera_ForecastHistoryY) - 1])",
+                                                "Object.Variable(__SmoothCamera_ForecastHistoryX[Object.VariableChildCount(__SmoothCamera_ForecastHistoryX) - 1])",
+                                                ""
+                                              ]
+                                            }
+                                          ]
+                                        },
+                                        {
+                                          "type": "BuiltinCommonInstructions::Comment",
+                                          "color": {
+                                            "b": 109,
+                                            "g": 230,
+                                            "r": 255,
+                                            "textB": 0,
+                                            "textG": 0,
+                                            "textR": 0
+                                          },
+                                          "comment": "Permute back axis",
+                                          "comment2": ""
+                                        },
+                                        {
+                                          "type": "BuiltinCommonInstructions::Standard",
+                                          "conditions": [],
+                                          "actions": [
+                                            {
+                                              "type": {
+                                                "value": "SmoothCamera::SmoothCamera::SetPropertyIndex"
+                                              },
+                                              "parameters": [
+                                                "Object",
+                                                "Behavior",
+                                                "=",
+                                                "Object.Behavior::PropertyProjectedOldestX()"
+                                              ]
+                                            },
+                                            {
+                                              "type": {
+                                                "value": "SmoothCamera::SmoothCamera::SetPropertyProjectedOldestX"
+                                              },
+                                              "parameters": [
+                                                "Object",
+                                                "Behavior",
+                                                "=",
+                                                "Object.Behavior::PropertyProjectedOldestY()"
+                                              ]
+                                            },
+                                            {
+                                              "type": {
+                                                "value": "SmoothCamera::SmoothCamera::SetPropertyProjectedOldestY"
+                                              },
+                                              "parameters": [
+                                                "Object",
+                                                "Behavior",
+                                                "=",
+                                                "Object.Behavior::PropertyIndex()"
+                                              ]
+                                            }
+                                          ]
+                                        },
+                                        {
+                                          "type": "BuiltinCommonInstructions::Standard",
+                                          "conditions": [],
+                                          "actions": [
+                                            {
+                                              "type": {
+                                                "value": "SmoothCamera::SmoothCamera::SetPropertyIndex"
+                                              },
+                                              "parameters": [
+                                                "Object",
+                                                "Behavior",
+                                                "=",
+                                                "Object.Behavior::PropertyProjectedNewestX()"
+                                              ]
+                                            },
+                                            {
+                                              "type": {
+                                                "value": "SmoothCamera::SmoothCamera::SetPropertyProjectedNewestX"
+                                              },
+                                              "parameters": [
+                                                "Object",
+                                                "Behavior",
+                                                "=",
+                                                "Object.Behavior::PropertyProjectedNewestY()"
+                                              ]
+                                            },
+                                            {
+                                              "type": {
+                                                "value": "SmoothCamera::SmoothCamera::SetPropertyProjectedNewestY"
+                                              },
+                                              "parameters": [
+                                                "Object",
+                                                "Behavior",
+                                                "=",
+                                                "Object.Behavior::PropertyIndex()"
+                                              ]
+                                            }
+                                          ]
+                                        }
+                                      ],
+                                      "parameters": []
+                                    },
+                                    {
+                                      "disabled": true,
+                                      "type": "BuiltinCommonInstructions::Standard",
+                                      "conditions": [],
+                                      "actions": [
+                                        {
+                                          "type": {
+                                            "value": "DebuggerTools::ConsoleLog"
+                                          },
+                                          "parameters": [
+                                            "\"Oldest: \" + ToString(Object.Behavior::PropertyProjectedOldestX()) + \" \" + ToString(Object.Behavior::PropertyProjectedOldestY())",
+                                            "\"info\"",
+                                            "\"SmoothCamera\""
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "disabled": true,
+                                      "type": "BuiltinCommonInstructions::Standard",
+                                      "conditions": [],
+                                      "actions": [
+                                        {
+                                          "type": {
+                                            "value": "DebuggerTools::ConsoleLog"
+                                          },
+                                          "parameters": [
+                                            "\"Newest: \" + ToString(Object.Behavior::PropertyProjectedNewestX()) + \" \" + ToString(Object.Behavior::PropertyProjectedNewestY())",
+                                            "\"info\"",
+                                            "\"SmoothCamera\""
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                },
+                                {
+                                  "colorB": 228,
+                                  "colorG": 176,
+                                  "colorR": 74,
+                                  "creationTime": 0,
+                                  "name": "Forcasted position",
+                                  "source": "",
+                                  "type": "BuiltinCommonInstructions::Group",
+                                  "events": [
+                                    {
+                                      "type": "BuiltinCommonInstructions::Standard",
+                                      "conditions": [],
+                                      "actions": [
+                                        {
+                                          "type": {
+                                            "value": "SmoothCamera::SmoothCamera::SetPropertyForecastedX"
+                                          },
+                                          "parameters": [
+                                            "Object",
+                                            "Behavior",
+                                            "=",
+                                            "Object.Behavior::PropertyProjectedNewestX() + ( Object.Behavior::PropertyProjectedNewestX() - Object.Behavior::PropertyProjectedOldestX()) * Object.Behavior::ForecastTimeRatio()"
+                                          ]
+                                        },
+                                        {
+                                          "type": {
+                                            "value": "SmoothCamera::SmoothCamera::SetPropertyForecastedY"
+                                          },
+                                          "parameters": [
+                                            "Object",
+                                            "Behavior",
+                                            "=",
+                                            "Object.Behavior::PropertyProjectedNewestY() + ( Object.Behavior::PropertyProjectedNewestY() - Object.Behavior::PropertyProjectedOldestY()) * Object.Behavior::ForecastTimeRatio()"
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "disabled": true,
+                                      "type": "BuiltinCommonInstructions::Standard",
+                                      "conditions": [],
+                                      "actions": [
+                                        {
+                                          "type": {
+                                            "value": "DebuggerTools::ConsoleLog"
+                                          },
+                                          "parameters": [
+                                            "\"Forecasted: \" + ToString(Object.Behavior::PropertyForecastedX()) + \" \" + ToString(Object.Behavior::PropertyForecastedY())",
+                                            "\"info\"",
+                                            "\"SmoothCamera\""
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  ],
+                                  "parameters": []
+                                }
+                              ],
+                              "parameters": []
+                            }
+                          ]
+                        }
+                      ],
+                      "parameters": []
+                    }
+                  ]
+                }
+              ],
+              "parameters": [
+                {
+                  "codeOnly": false,
+                  "defaultValue": "",
+                  "description": "Object",
+                  "longDescription": "",
+                  "name": "Object",
+                  "optional": false,
+                  "supplementaryInformation": "",
+                  "type": "object"
+                },
+                {
+                  "codeOnly": false,
+                  "defaultValue": "",
+                  "description": "Behavior",
+                  "longDescription": "",
+                  "name": "Behavior",
+                  "optional": false,
+                  "supplementaryInformation": "SmoothCamera::SmoothCamera",
+                  "type": "behavior"
+                }
+              ],
+              "objectGroups": []
+            },
+            {
+              "description": "Project history ends position to have the vector on the line from linear regression. This function is only called by UpdateForecastedPosition.",
+              "fullName": "Project history ends",
+              "functionType": "Action",
+              "group": "Private",
+              "name": "ProjectHistoryEnds",
+              "private": true,
+              "sentence": "Project history oldest: _PARAM2_;_PARAM3_ and newest position: _PARAM4_;_PARAM5_ of _PARAM0_",
+              "events": [
+                {
+                  "type": "BuiltinCommonInstructions::Comment",
+                  "color": {
+                    "b": 109,
+                    "g": 230,
+                    "r": 255,
+                    "textB": 0,
+                    "textG": 0,
+                    "textR": 0
+                  },
+                  "comment": "Perpendicular line:\npA = -1/a; \npB = -pA * x + y\n\nIntersection:\n/ ProjectedY = a * ProjectedX + b\n\\ ProjectedY = pA * ProjectedX + b\n\nSolution that is cleaned out from indeterminism (like 0 / 0 or infinity / infinity):\nProjectedX= (x + (y - b) * a) / (a² + 1)\nProjectedY = y + (x * a - y + b) / (a² + 1)",
+                  "comment2": ""
+                },
+                {
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [],
+                  "actions": [
+                    {
+                      "type": {
+                        "value": "SmoothCamera::SmoothCamera::SetPropertyProjectedNewestX"
+                      },
+                      "parameters": [
+                        "Object",
+                        "Behavior",
+                        "=",
+                        "(GetArgumentAsNumber(\"NewestX\") + (GetArgumentAsNumber(\"NewestY\") - Object.Behavior::PropertyForecastHistoryLinearB()) * Object.Behavior::PropertyForecastHistoryLinearA()) / (1 + pow(Object.Behavior::PropertyForecastHistoryLinearA(), 2))"
+                      ]
+                    },
+                    {
+                      "type": {
+                        "value": "SmoothCamera::SmoothCamera::SetPropertyProjectedNewestY"
+                      },
+                      "parameters": [
+                        "Object",
+                        "Behavior",
+                        "=",
+                        "GetArgumentAsNumber(\"NewestY\") + (GetArgumentAsNumber(\"NewestX\") * Object.Behavior::PropertyForecastHistoryLinearA() - GetArgumentAsNumber(\"NewestY\") \n+ Object.Behavior::PropertyForecastHistoryLinearB()) / (1 + pow(Object.Behavior::PropertyForecastHistoryLinearA(), 2))"
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [],
+                  "actions": [
+                    {
+                      "type": {
+                        "value": "SmoothCamera::SmoothCamera::SetPropertyProjectedOldestX"
+                      },
+                      "parameters": [
+                        "Object",
+                        "Behavior",
+                        "=",
+                        "(GetArgumentAsNumber(\"OldestX\") + (GetArgumentAsNumber(\"OldestY\") - Object.Behavior::PropertyForecastHistoryLinearB()) * Object.Behavior::PropertyForecastHistoryLinearA()) / (1 + pow(Object.Behavior::PropertyForecastHistoryLinearA(), 2))"
+                      ]
+                    },
+                    {
+                      "type": {
+                        "value": "SmoothCamera::SmoothCamera::SetPropertyProjectedOldestY"
+                      },
+                      "parameters": [
+                        "Object",
+                        "Behavior",
+                        "=",
+                        "GetArgumentAsNumber(\"OldestY\") + (GetArgumentAsNumber(\"OldestX\") * Object.Behavior::PropertyForecastHistoryLinearA() - GetArgumentAsNumber(\"OldestY\") \n+ Object.Behavior::PropertyForecastHistoryLinearB()) / (1 + pow(Object.Behavior::PropertyForecastHistoryLinearA(), 2))"
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "parameters": [
+                {
+                  "codeOnly": false,
+                  "defaultValue": "",
+                  "description": "Object",
+                  "longDescription": "",
+                  "name": "Object",
+                  "optional": false,
+                  "supplementaryInformation": "",
+                  "type": "object"
+                },
+                {
+                  "codeOnly": false,
+                  "defaultValue": "",
+                  "description": "Behavior",
+                  "longDescription": "",
+                  "name": "Behavior",
+                  "optional": false,
+                  "supplementaryInformation": "SmoothCamera::SmoothCamera",
+                  "type": "behavior"
+                },
+                {
+                  "codeOnly": false,
+                  "defaultValue": "",
+                  "description": "OldestX",
+                  "longDescription": "",
+                  "name": "OldestX",
+                  "optional": false,
+                  "supplementaryInformation": "",
+                  "type": "expression"
+                },
+                {
+                  "codeOnly": false,
+                  "defaultValue": "",
+                  "description": "OldestY",
+                  "longDescription": "",
+                  "name": "OldestY",
+                  "optional": false,
+                  "supplementaryInformation": "",
+                  "type": "expression"
+                },
+                {
+                  "codeOnly": false,
+                  "defaultValue": "",
+                  "description": "Newest X",
+                  "longDescription": "",
+                  "name": "NewestX",
+                  "optional": false,
+                  "supplementaryInformation": "",
+                  "type": "expression"
+                },
+                {
+                  "codeOnly": false,
+                  "defaultValue": "",
+                  "description": "Newest Y",
+                  "longDescription": "",
+                  "name": "NewestY",
+                  "optional": false,
+                  "supplementaryInformation": "",
+                  "type": "expression"
+                }
+              ],
+              "objectGroups": []
+            },
+            {
+              "description": "Return the ratio between forecast time and the duration of the history. This function is only called by UpdateForecastedPosition.",
+              "fullName": "Forecast time ratio",
+              "functionType": "Expression",
+              "group": "Private",
+              "name": "ForecastTimeRatio",
+              "private": true,
+              "sentence": "",
+              "events": [
+                {
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [],
+                  "actions": [
+                    {
+                      "type": {
+                        "value": "SetReturnNumber"
+                      },
+                      "parameters": [
+                        "- Object.Behavior::PropertyForecastTime() / (Object.Variable(__SmoothCamera_ForecastHistoryTime[0]) - Object.Variable(__SmoothCamera_ForecastHistoryTime[Object.VariableChildCount(__SmoothCamera_ForecastHistoryTime) - 1]))"
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "parameters": [
+                {
+                  "codeOnly": false,
+                  "defaultValue": "",
+                  "description": "Object",
+                  "longDescription": "",
+                  "name": "Object",
+                  "optional": false,
+                  "supplementaryInformation": "",
+                  "type": "object"
+                },
+                {
+                  "codeOnly": false,
+                  "defaultValue": "",
+                  "description": "Behavior",
+                  "longDescription": "",
+                  "name": "Behavior",
+                  "optional": false,
+                  "supplementaryInformation": "SmoothCamera::SmoothCamera",
+                  "type": "behavior"
+                }
+              ],
+              "objectGroups": []
+            }
+          ],
+          "propertyDescriptors": [
+            {
+              "value": "0.9",
+              "type": "Number",
+              "label": "Leftward catch-up speed (in ratio per second)",
+              "description": "",
+              "group": "Catch-up speed",
+              "extraInformation": [],
+              "hidden": false,
+              "name": "LeftwardSpeed"
+            },
+            {
+              "value": "0.9",
+              "type": "Number",
+              "label": "Rightward catch-up speed (in ratio per second)",
+              "description": "",
+              "group": "Catch-up speed",
+              "extraInformation": [],
+              "hidden": false,
+              "name": "RightwardSpeed"
+            },
+            {
+              "value": "0.9",
+              "type": "Number",
+              "label": "Upward catch-up speed (in ratio per second)",
+              "description": "",
+              "group": "Catch-up speed",
+              "extraInformation": [],
+              "hidden": false,
+              "name": "UpwardSpeed"
+            },
+            {
+              "value": "0.9",
+              "type": "Number",
+              "label": "Downward catch-up speed (in ratio per second)",
+              "description": "",
+              "group": "Catch-up speed",
+              "extraInformation": [],
+              "hidden": false,
+              "name": "DownwardSpeed"
+            },
+            {
+              "value": "true",
+              "type": "Boolean",
+              "label": "Follow on X axis",
+              "description": "",
+              "group": "",
+              "extraInformation": [],
+              "hidden": false,
+              "name": "FollowOnX"
+            },
+            {
+              "value": "true",
+              "type": "Boolean",
+              "label": "Follow on Y axis",
+              "description": "",
+              "group": "",
+              "extraInformation": [],
+              "hidden": false,
+              "name": "FollowOnY"
+            },
+            {
+              "value": "0",
+              "type": "Number",
+              "label": "Follow free area left border",
+              "description": "",
+              "group": "Position",
+              "extraInformation": [],
+              "hidden": false,
+              "name": "FollowFreeAreaLeft"
+            },
+            {
+              "value": "0",
+              "type": "Number",
+              "label": "Follow free area right border",
+              "description": "",
+              "group": "Position",
+              "extraInformation": [],
+              "hidden": false,
+              "name": "FollowFreeAreaRight"
+            },
+            {
+              "value": "0",
+              "type": "Number",
+              "label": "Follow free area top border",
+              "description": "",
+              "group": "Position",
+              "extraInformation": [],
+              "hidden": false,
+              "name": "FollowFreeAreaTop"
+            },
+            {
+              "value": "0",
+              "type": "Number",
+              "label": "Follow free area bottom border",
+              "description": "",
+              "group": "Position",
+              "extraInformation": [],
+              "hidden": false,
+              "name": "FollowFreeAreaBottom"
+            },
+            {
+              "value": "0",
+              "type": "Number",
+              "label": "Camera offset X",
+              "description": "",
+              "group": "Position",
+              "extraInformation": [],
+              "hidden": false,
+              "name": "CameraOffsetX"
+            },
+            {
+              "value": "0",
+              "type": "Number",
+              "label": "Camera offset Y",
+              "description": "",
+              "group": "Position",
+              "extraInformation": [],
+              "hidden": false,
+              "name": "CameraOffsetY"
+            },
+            {
+              "value": "0",
+              "type": "Number",
+              "label": "Camera delay (in seconds)",
+              "description": "",
+              "group": "Timing",
+              "extraInformation": [],
+              "hidden": false,
+              "name": "CameraDelay"
+            },
+            {
+              "value": "0",
+              "type": "Number",
+              "label": "Forcast time (in seconds)",
+              "description": "",
+              "group": "Timing",
+              "extraInformation": [],
+              "hidden": false,
+              "name": "ForecastTime"
+            },
+            {
+              "value": "0",
+              "type": "Number",
+              "label": "Forecast history duration (in second)",
+              "description": "",
+              "group": "Timing",
+              "extraInformation": [],
+              "hidden": false,
+              "name": "ForecastHistoryDuration"
+            },
+            {
+              "value": "",
+              "type": "Number",
+              "label": "",
+              "description": "",
+              "group": "",
+              "extraInformation": [],
+              "hidden": true,
+              "name": "LogLeftwardSpeed"
+            },
+            {
+              "value": "",
+              "type": "Number",
+              "label": "",
+              "description": "",
+              "group": "",
+              "extraInformation": [],
+              "hidden": true,
+              "name": "LogRightwardSpeed"
+            },
+            {
+              "value": "",
+              "type": "Number",
+              "label": "",
+              "description": "",
+              "group": "",
+              "extraInformation": [],
+              "hidden": true,
+              "name": "LogDownwardSpeed"
+            },
+            {
+              "value": "",
+              "type": "Number",
+              "label": "",
+              "description": "",
+              "group": "",
+              "extraInformation": [],
+              "hidden": true,
+              "name": "LogUpwardSpeed"
+            },
+            {
+              "value": "",
+              "type": "Number",
+              "label": "",
+              "description": "",
+              "group": "",
+              "extraInformation": [],
+              "hidden": true,
+              "name": "DelayedCenterX"
+            },
+            {
+              "value": "",
+              "type": "Number",
+              "label": "",
+              "description": "",
+              "group": "",
+              "extraInformation": [],
+              "hidden": true,
+              "name": "DelayedCenterY"
+            },
+            {
+              "value": "",
+              "type": "Number",
+              "label": "",
+              "description": "",
+              "group": "",
+              "extraInformation": [],
+              "hidden": true,
+              "name": "ForecastHistoryMeanX"
+            },
+            {
+              "value": "",
+              "type": "Number",
+              "label": "",
+              "description": "",
+              "group": "",
+              "extraInformation": [],
+              "hidden": true,
+              "name": "ForecastHistoryMeanY"
+            },
+            {
+              "value": "",
+              "type": "Number",
+              "label": "",
+              "description": "",
+              "group": "",
+              "extraInformation": [],
+              "hidden": true,
+              "name": "ForecastHistoryVarianceX"
+            },
+            {
+              "value": "",
+              "type": "Number",
+              "label": "",
+              "description": "",
+              "group": "",
+              "extraInformation": [],
+              "hidden": true,
+              "name": "ForecastHistoryCovariance"
+            },
+            {
+              "value": "",
+              "type": "Number",
+              "label": "",
+              "description": "",
+              "group": "",
+              "extraInformation": [],
+              "hidden": true,
+              "name": "ForecastHistoryLinearA"
+            },
+            {
+              "value": "",
+              "type": "Number",
+              "label": "",
+              "description": "",
+              "group": "",
+              "extraInformation": [],
+              "hidden": true,
+              "name": "ForecastHistoryLinearB"
+            },
+            {
+              "value": "",
+              "type": "Number",
+              "label": "",
+              "description": "",
+              "group": "",
+              "extraInformation": [],
+              "hidden": true,
+              "name": "ForecastedX"
+            },
+            {
+              "value": "",
+              "type": "Number",
+              "label": "",
+              "description": "",
+              "group": "",
+              "extraInformation": [],
+              "hidden": true,
+              "name": "ForecastedY"
+            },
+            {
+              "value": "",
+              "type": "Number",
+              "label": "",
+              "description": "",
+              "group": "",
+              "extraInformation": [],
+              "hidden": true,
+              "name": "ProjectedNewestX"
+            },
+            {
+              "value": "",
+              "type": "Number",
+              "label": "",
+              "description": "",
+              "group": "",
+              "extraInformation": [],
+              "hidden": true,
+              "name": "ProjectedNewestY"
+            },
+            {
+              "value": "",
+              "type": "Number",
+              "label": "",
+              "description": "",
+              "group": "",
+              "extraInformation": [],
+              "hidden": true,
+              "name": "ProjectedOldestX"
+            },
+            {
+              "value": "",
+              "type": "Number",
+              "label": "",
+              "description": "",
+              "group": "",
+              "extraInformation": [],
+              "hidden": true,
+              "name": "ProjectedOldestY"
+            },
+            {
+              "value": "",
+              "type": "Number",
+              "label": "",
+              "description": "",
+              "group": "",
+              "extraInformation": [],
+              "hidden": true,
+              "name": "ForecastHistoryVarianceY"
+            },
+            {
+              "value": "",
+              "type": "Number",
+              "label": "Index (local variable)",
+              "description": "",
+              "group": "",
+              "extraInformation": [],
+              "hidden": true,
+              "name": "Index"
+            },
+            {
+              "value": "0",
+              "type": "Number",
+              "label": "",
+              "description": "",
+              "group": "",
+              "extraInformation": [],
+              "hidden": true,
+              "name": "CameraDelayCatchUpSpeed"
+            },
+            {
+              "value": "",
+              "type": "Number",
+              "label": "",
+              "description": "",
+              "group": "",
+              "extraInformation": [],
+              "hidden": true,
+              "name": "CameraExtraDelay"
+            },
+            {
+              "value": "",
+              "type": "Number",
+              "label": "",
+              "description": "",
+              "group": "",
+              "extraInformation": [],
+              "hidden": true,
+              "name": "WaitingSpeedXMax"
+            },
+            {
+              "value": "",
+              "type": "Number",
+              "label": "",
+              "description": "",
+              "group": "",
+              "extraInformation": [],
+              "hidden": true,
+              "name": "WaitingSpeedYMax"
+            },
+            {
+              "value": "",
+              "type": "Number",
+              "label": "",
+              "description": "",
+              "group": "",
+              "extraInformation": [],
+              "hidden": true,
+              "name": "WaitingEnd"
+            },
+            {
+              "value": "",
+              "type": "Number",
+              "label": "",
+              "description": "",
+              "group": "",
+              "extraInformation": [],
+              "hidden": true,
+              "name": "CameraDelayCatchUpDuration"
+            },
+            {
+              "value": "9000",
+              "type": "Number",
+              "label": "Leftward maximum speed (in pixels per second)",
+              "description": "",
+              "group": "Maximum speed",
+              "extraInformation": [],
+              "hidden": false,
+              "name": "LeftwardSpeedMax"
+            },
+            {
+              "value": "9000",
+              "type": "Number",
+              "label": "Rightward maximum speed (in pixels per second)",
+              "description": "",
+              "group": "Maximum speed",
+              "extraInformation": [],
+              "hidden": false,
+              "name": "RightwardSpeedMax"
+            },
+            {
+              "value": "9000",
+              "type": "Number",
+              "label": "Upward maximum speed (in pixels per second)",
+              "description": "",
+              "group": "Maximum speed",
+              "extraInformation": [],
+              "hidden": false,
+              "name": "UpwardSpeedMax"
+            },
+            {
+              "value": "9000",
+              "type": "Number",
+              "label": "Downward maximum speed (in pixels per second)",
+              "description": "",
+              "group": "Maximum speed",
+              "extraInformation": [],
+              "hidden": false,
+              "name": "DownwardSpeedMax"
+            },
+            {
+              "value": "",
+              "type": "Number",
+              "label": "OldX (local variable)",
+              "description": "",
+              "group": "",
+              "extraInformation": [],
+              "hidden": true,
+              "name": "OldX"
+            },
+            {
+              "value": "",
+              "type": "Number",
+              "label": "OldY (local variable)",
+              "description": "",
+              "group": "",
+              "extraInformation": [],
+              "hidden": true,
+              "name": "OldY"
+            }
+          ]
+        },
+        {
+          "description": "Smoothly scroll to follow a character and stabilize the camera when jumping.",
+          "fullName": "Smooth platformer camera",
+          "name": "SmoothPlatformerCamera",
+          "objectType": "",
+          "eventsFunctions": [
+            {
+              "description": "",
+              "fullName": "",
+              "functionType": "Action",
+              "group": "",
+              "name": "doStepPreEvents",
+              "private": false,
+              "sentence": "",
+              "events": [
+                {
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [
+                    {
+                      "type": {
+                        "inverted": true,
+                        "value": "PlatformBehavior::IsJumping"
+                      },
+                      "parameters": [
+                        "Object",
+                        "PlatformerCharacter"
+                      ]
+                    },
+                    {
+                      "type": {
+                        "inverted": true,
+                        "value": "PlatformBehavior::IsFalling"
+                      },
+                      "parameters": [
+                        "Object",
+                        "PlatformerCharacter"
+                      ]
+                    }
+                  ],
+                  "actions": [
+                    {
+                      "type": {
+                        "value": "SmoothCamera::SmoothCamera::SetFollowFreeAreaBottom"
+                      },
+                      "parameters": [
+                        "Object",
+                        "SmoothCamera",
+                        "Object.Behavior::PropertyFloorFollowFreeAreaTop()",
+                        ""
+                      ]
+                    },
+                    {
+                      "type": {
+                        "value": "SmoothCamera::SmoothCamera::SetFollowFreeAreaTop"
+                      },
+                      "parameters": [
+                        "Object",
+                        "SmoothCamera",
+                        "Object.Behavior::PropertyFloorFollowFreeAreaBottom()",
+                        ""
+                      ]
+                    },
+                    {
+                      "type": {
+                        "value": "SmoothCamera::SmoothCamera::SetUpwardSpeed"
+                      },
+                      "parameters": [
+                        "Object",
+                        "SmoothCamera",
+                        "Object.Behavior::PropertyFloorUpwardSpeed()",
+                        ""
+                      ]
+                    },
+                    {
+                      "type": {
+                        "value": "SmoothCamera::SmoothCamera::SetDownwardSpeed"
+                      },
+                      "parameters": [
+                        "Object",
+                        "SmoothCamera",
+                        "Object.Behavior::PropertyFloorDownwardSpeed()",
+                        ""
+                      ]
+                    },
+                    {
+                      "type": {
+                        "value": "SmoothCamera::SmoothCamera::SetUpwardSpeedMax"
+                      },
+                      "parameters": [
+                        "Object",
+                        "SmoothCamera",
+                        "Object.Behavior::PropertyFloorUpwardSpeedMax()",
+                        ""
+                      ]
+                    },
+                    {
+                      "type": {
+                        "value": "SmoothCamera::SmoothCamera::SetDownwardSpeedMax"
+                      },
+                      "parameters": [
+                        "Object",
+                        "SmoothCamera",
+                        "Object.Behavior::PropertyFloorDownwardSpeedMax()",
+                        ""
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "BuiltinCommonInstructions::Standard",
+                  "conditions": [
+                    {
+                      "type": {
+                        "value": "BuiltinCommonInstructions::Or"
+                      },
+                      "parameters": [],
+                      "subInstructions": [
+                        {
+                          "type": {
+                            "value": "PlatformBehavior::IsJumping"
+                          },
+                          "parameters": [
+                            "Object",
+                            "PlatformerCharacter"
+                          ]
+                        },
+                        {
+                          "type": {
+                            "value": "PlatformBehavior::IsFalling"
+                          },
+                          "parameters": [
+                            "Object",
+                            "PlatformerCharacter"
+                          ]
+                        }
+                      ]
+                    }
+                  ],
+                  "actions": [
+                    {
+                      "type": {
+                        "value": "SmoothCamera::SmoothCamera::SetFollowFreeAreaBottom"
+                      },
+                      "parameters": [
+                        "Object",
+                        "SmoothCamera",
+                        "Object.Behavior::PropertyAirFollowFreeAreaTop()",
+                        ""
+                      ]
+                    },
+                    {
+                      "type": {
+                        "value": "SmoothCamera::SmoothCamera::SetFollowFreeAreaTop"
+                      },
+                      "parameters": [
+                        "Object",
+                        "SmoothCamera",
+                        "Object.Behavior::PropertyAirFollowFreeAreaBottom()",
+                        ""
+                      ]
+                    },
+                    {
+                      "type": {
+                        "value": "SmoothCamera::SmoothCamera::SetUpwardSpeed"
+                      },
+                      "parameters": [
+                        "Object",
+                        "SmoothCamera",
+                        "Object.Behavior::PropertyAirUpwardSpeed()",
+                        ""
+                      ]
+                    },
+                    {
+                      "type": {
+                        "value": "SmoothCamera::SmoothCamera::SetDownwardSpeed"
+                      },
+                      "parameters": [
+                        "Object",
+                        "SmoothCamera",
+                        "Object.Behavior::PropertyAirDownwardSpeed()",
+                        ""
+                      ]
+                    },
+                    {
+                      "type": {
+                        "value": "SmoothCamera::SmoothCamera::SetUpwardSpeedMax"
+                      },
+                      "parameters": [
+                        "Object",
+                        "SmoothCamera",
+                        "Object.Behavior::PropertyAirUpwardSpeedMax()",
+                        ""
+                      ]
+                    },
+                    {
+                      "type": {
+                        "value": "SmoothCamera::SmoothCamera::SetDownwardSpeedMax"
+                      },
+                      "parameters": [
+                        "Object",
+                        "SmoothCamera",
+                        "Object.Behavior::PropertyAirDownwardSpeedMax()",
+                        ""
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "parameters": [
+                {
+                  "codeOnly": false,
+                  "defaultValue": "",
+                  "description": "Object",
+                  "longDescription": "",
+                  "name": "Object",
+                  "optional": false,
+                  "supplementaryInformation": "",
+                  "type": "object"
+                },
+                {
+                  "codeOnly": false,
+                  "defaultValue": "",
+                  "description": "Behavior",
+                  "longDescription": "",
+                  "name": "Behavior",
+                  "optional": false,
+                  "supplementaryInformation": "SmoothCamera::SmoothPlatformerCamera",
+                  "type": "behavior"
+                }
+              ],
+              "objectGroups": []
+            }
+          ],
+          "propertyDescriptors": [
+            {
+              "value": "",
+              "type": "Behavior",
+              "label": "Platformer character behavior",
+              "description": "",
+              "group": "",
+              "extraInformation": [
+                "PlatformBehavior::PlatformerObjectBehavior"
+              ],
+              "hidden": false,
+              "name": "PlatformerCharacter"
+            },
+            {
+              "value": "",
+              "type": "Behavior",
+              "label": "Smooth camera behavior",
+              "description": "",
+              "group": "",
+              "extraInformation": [
+                "SmoothCamera::SmoothCamera"
+              ],
+              "hidden": false,
+              "name": "SmoothCamera"
+            },
+            {
+              "value": "",
+              "type": "Number",
+              "label": "",
+              "description": "",
+              "group": "",
+              "extraInformation": [],
+              "hidden": true,
+              "name": "JumpOriginY"
+            },
+            {
+              "value": "0",
+              "type": "Number",
+              "label": "Follow free area top in the air",
+              "description": "",
+              "group": "Position",
+              "extraInformation": [],
+              "hidden": false,
+              "name": "AirFollowFreeAreaTop"
+            },
+            {
+              "value": "0",
+              "type": "Number",
+              "label": "Follow free area bottom in the air",
+              "description": "",
+              "group": "Position",
+              "extraInformation": [],
+              "hidden": false,
+              "name": "AirFollowFreeAreaBottom"
+            },
+            {
+              "value": "0",
+              "type": "Number",
+              "label": "Follow free area top on the floor",
+              "description": "",
+              "group": "Position",
+              "extraInformation": [],
+              "hidden": false,
+              "name": "FloorFollowFreeAreaTop"
+            },
+            {
+              "value": "0",
+              "type": "Number",
+              "label": "Follow free area bottom on the floor",
+              "description": "",
+              "group": "Position",
+              "extraInformation": [],
+              "hidden": false,
+              "name": "FloorFollowFreeAreaBottom"
+            },
+            {
+              "value": "0.95",
+              "type": "Number",
+              "label": "Upward speed in the air (in ratio persecond)",
+              "description": "",
+              "group": "Catch-up speed",
+              "extraInformation": [],
+              "hidden": false,
+              "name": "AirUpwardSpeed"
+            },
+            {
+              "value": "0.95",
+              "type": "Number",
+              "label": "Downward speed in the air (in ratio persecond)",
+              "description": "",
+              "group": "Catch-up speed",
+              "extraInformation": [],
+              "hidden": false,
+              "name": "AirDownwardSpeed"
+            },
+            {
+              "value": "0.9",
+              "type": "Number",
+              "label": "Upward speed on the floor (in ratio persecond)",
+              "description": "",
+              "group": "Catch-up speed",
+              "extraInformation": [],
+              "hidden": false,
+              "name": "FloorUpwardSpeed"
+            },
+            {
+              "value": "0.9",
+              "type": "Number",
+              "label": "Downward speed on the floor (in ratio persecond)",
+              "description": "",
+              "group": "Catch-up speed",
+              "extraInformation": [],
+              "hidden": false,
+              "name": "FloorDownwardSpeed"
+            },
+            {
+              "value": "9000",
+              "type": "Number",
+              "label": "Upward maximum speed in the air (in pixels per second)",
+              "description": "",
+              "group": "Maximum speed",
+              "extraInformation": [],
+              "hidden": false,
+              "name": "AirUpwardSpeedMax"
+            },
+            {
+              "value": "9000",
+              "type": "Number",
+              "label": "Downward maximum speed in the air (in pixels per second)",
+              "description": "",
+              "group": "Maximum speed",
+              "extraInformation": [],
+              "hidden": false,
+              "name": "AirDownwardSpeedMax"
+            },
+            {
+              "value": "9000",
+              "type": "Number",
+              "label": "Upward maximum speed on the floor (in pixels per second)",
+              "description": "",
+              "group": "Maximum speed",
+              "extraInformation": [],
+              "hidden": false,
+              "name": "FloorUpwardSpeedMax"
+            },
+            {
+              "value": "9000",
+              "type": "Number",
+              "label": "Downward maximum speed on the floor (in pixels per second)",
+              "description": "",
+              "group": "Maximum speed",
+              "extraInformation": [],
+              "hidden": false,
+              "name": "FloorDownwardSpeedMax"
+            }
+          ]
+        }
+      ]
+    },
     {
       "author": "",
       "category": "",


### PR DESCRIPTION
Changes:
- Use a smooth camera instead of a direct centering
- Change the platformer character jump settings