### PR TITLE
Ball Cup Boom (v1.0.3): Modified vibration to 25 ms

### DIFF
--- a/examples/ball-cup-boom/ball-cup-boom.json
+++ b/examples/ball-cup-boom/ball-cup-boom.json
@@ -15276,6 +15276,14 @@
             },
             {
               "type": {
+                "value": "DeviceVibration::StartVibration"
+              },
+              "parameters": [
+                "25"
+              ]
+            },
+            {
+              "type": {
                 "value": "Wait"
               },
               "parameters": [
@@ -16476,7 +16484,7 @@
                                         "value": "DeviceVibration::StartVibration"
                                       },
                                       "parameters": [
-                                        "10"
+                                        "25"
                                       ]
                                     }
                                   ]
@@ -17193,7 +17201,7 @@
                                 "value": "DeviceVibration::StartVibration"
                               },
                               "parameters": [
-                                "10"
+                                "25"
                               ]
                             },
                             {


### PR DESCRIPTION
10 ms was too small and nothing vibrated.  Trying 25 ms,