### PR TITLE
Update GitHub action

### DIFF
--- a/.github/workflows/calibreapp-image-actions.yml
+++ b/.github/workflows/calibreapp-image-actions.yml
@@ -35,7 +35,7 @@ jobs:
        github.event.pull_request.head.repo.full_name == github.repository)
     steps:
       - name: Checkout Branch
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Compress Images
         id: calibre
         uses: calibreapp/image-actions@main
@@ -48,7 +48,7 @@ jobs:
         if: |
           github.event_name != 'pull_request' &&
           steps.calibre.outputs.markdown != ''
-        uses: peter-evans/create-pull-request@v3
+        uses: peter-evans/create-pull-request@v5
         with:
           title: Auto Compress Images
           branch-suffix: timestamp

--- a/.github/workflows/comment-links-to-changed-games-in-pull-requests.yml
+++ b/.github/workflows/comment-links-to-changed-games-in-pull-requests.yml
@@ -11,7 +11,7 @@ jobs:
 
       - name: Get changed files
         id: changed-game-files
-        uses: tj-actions/changed-files@v23.1
+        uses: tj-actions/changed-files@v35
         with:
           files: |
             examples/**/*.json
@@ -42,7 +42,7 @@ jobs:
           body-includes: "### Preview the game(s) changed or added in this Pull Request"
 
       - name: Create or update comment
-        uses: peter-evans/create-or-update-comment@v2
+        uses: peter-evans/create-or-update-comment@v3
         with:
           comment-id: ${{ steps.fc.outputs.comment-id }}
           issue-number: ${{ github.event.pull_request.number }}

--- a/.github/workflows/comment-links-to-changed-games-in-pull-requests.yml
+++ b/.github/workflows/comment-links-to-changed-games-in-pull-requests.yml
@@ -31,7 +31,7 @@ jobs:
           CHANGED_GAMES_LINKS="${CHANGED_GAMES_LINKS//$'\n'/'%0A'}"
           CHANGED_GAMES_LINKS="${CHANGED_GAMES_LINKS//$'\r'/'%0D'}"
 
-          echo "::set-output name=changed-games-links::$CHANGED_GAMES_LINKS"
+          echo "changed-games-links=$CHANGED_GAMES_LINKS" >> $GITHUB_OUTPUT
 
       - name: Find the existing comment about games in the PR
         uses: peter-evans/find-comment@v2


### PR DESCRIPTION
1. Bumps [actions/checkout](https://github.com/actions/checkout) from v2 to v3
2. Bumps [peter-evans/create-pull-request](https://github.com/peter-evans/create-pull-request) from v3 to v5
3. Bumps [peter-evans/create-or-update-comment](https://github.com/peter-evans/create-or-update-comment) from v2 to v3
4. Bumps [tj-actions/changed-files](https://github.com/tj-actions/changed-files) from v23.1 to v35
5. Fix github action deprecated [(link)](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)