### PR TITLE
Updating the multiplayer arrow fight game

### DIFF
--- a/examples/multiplayer-platformer-arrow-fight/multiplayer-platformer-arrow-fight.json
+++ b/examples/multiplayer-platformer-arrow-fight/multiplayer-platformer-arrow-fight.json
@@ -976,7 +976,7 @@
         "gridColor": 10401023,
         "gridAlpha": 0.8,
         "snap": true,
-        "zoomFactor": 1.0269425874981166,
+        "zoomFactor": 0.5290357402156889,
         "windowMask": false
       },
       "objectsGroups": [
@@ -3825,12 +3825,6 @@
           "effects": [],
           "behaviors": [
             {
-              "name": "MultiplayerObject",
-              "type": "Multiplayer::MultiplayerObjectBehavior",
-              "playerNumber": 0,
-              "actionOnPlayerDisconnect": "DestroyObject"
-            },
-            {
               "name": "Tween",
               "type": "Tween::TweenBehavior"
             }
@@ -3922,12 +3916,6 @@
           "variables": [],
           "effects": [],
           "behaviors": [
-            {
-              "name": "MultiplayerObject",
-              "type": "Multiplayer::MultiplayerObjectBehavior",
-              "playerNumber": 1,
-              "actionOnPlayerDisconnect": "DestroyObject"
-            },
             {
               "name": "Tween",
               "type": "Tween::TweenBehavior"
@@ -6000,7 +5988,7 @@
                   },
                   "parameters": [
                     "Paused",
-                    "True",
+                    "Toggle",
                     "abs(Paused - 1)"
                   ]
                 }


### PR DESCRIPTION
Updates:
-Fixed pause button, it was "set to true" and needed to be changed to toggle in order to be turned off once the game was paused. 
-Removed the multiplayer behavior from the pause text and button, the behavior was conflicting with the tween events and weren't needed.