### PR TITLE
Fix NPC "Selected" variable defaulting to true in the point-and-click adventures

### DIFF
--- a/examples/starting-3d-point-and-click-adventure/starting-3d-point-and-click-adventure.json
+++ b/examples/starting-3d-point-and-click-adventure/starting-3d-point-and-click-adventure.json
@@ -936,7 +936,7 @@
               "name": "Selected",
               "persistentUuid": "5865b5a1-2e82-402f-af68-40dc2ef53b38",
               "type": "boolean",
-              "value": true
+              "value": false
             }
           ],
           "effects": [],

--- a/examples/starting-point-and-click-adventure/starting-point-and-click-adventure.json
+++ b/examples/starting-point-and-click-adventure/starting-point-and-click-adventure.json
@@ -745,7 +745,7 @@
             {
               "name": "Selected",
               "type": "boolean",
-              "value": true
+              "value": false
             }
           ],
           "effects": [],


### PR DESCRIPTION
Found while writing gameplay tests: in `starting-point-and-click-adventure`, the `NPC` object's `Selected` boolean variable defaults to **true**. Since the player spawns overlapping two NPCs, the collision event fires on the very first frame — the dialog layer is shown and the Pathfinding behavior deactivated before any input, so the game opens with a dialog up and the player frozen.